### PR TITLE
feat[ISSUE-6]: add BDU vulnerability IDs to SBOM and reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ---
 
+## [Unreleased]
+
+### Добавлено
+
+- Опциональное BDU-обогащение уязвимостей через `--bdu` и переменную окружения `BDU`
+- Выгрузка `BDU / ID` в Excel, Word и ODT отчёты
+
+### Изменено
+
+- BDU ID в CycloneDX SBOM теперь сохраняется в `vulnerabilities[].properties[]` как `ru.fstec.bdu:id`
+
 ## [2.1.0] — 2026-03-21
 
 ### Добавлено

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - Генерирует SBOM из локальной директории или Git-репозитория (GitHub / GitLab)
 - Сканирует уязвимости через **Trivy**, **OWASP Dependency-Check**, **Clair**
 - Встраивает найденные уязвимости в SBOM (CycloneDX 1.5)
+- Опционально обогащает уязвимости идентификаторами **БДУ ФСТЭК**
 - Экспортирует читаемые отчёты: **Excel (.xlsx)**, **Word (.docx)**, **ODT (.odt)**
 - Подписывает итоговый SBOM (SHA-256)
 
@@ -88,6 +89,8 @@ pip install -e ".[dev]"
 | `secgensbom_out/merged-bom-signed.sig`  | SHA-256 контрольная сумма       |
 | `secgensbom_out/vulns-normalized.json`  | Нормализованные уязвимости      |
 
+Если включено BDU-обогащение, в `merged-bom-signed.json` идентификатор БДУ записывается в `vulnerabilities[].properties[]` как свойство с именем `ru.fstec.bdu:id`.
+
 ### Отчёты сканеров
 
 | Путь | Сканер |
@@ -104,6 +107,47 @@ pip install -e ".[dev]"
 | `secgensbom_reports/excel/*.xlsx` | Excel  | Лист 1: компоненты, Лист 2: уязвимости    |
 | `secgensbom_reports/docx/*.docx`  | Word   | Таблица компонентов + таблица уязвимостей |
 | `secgensbom_reports/odt/*.odt`    | ODT    | То же самое                               |
+
+Если пайплайн запущен с `--bdu` или `BDU=true`, во всех форматах отчётов уязвимостей появляется отдельная колонка `BDU / ID`. Если BDU-обогащение выключено, эта колонка не выводится.
+
+---
+
+## BDU Enrichment
+
+Обогащение идентификаторами БДУ ФСТЭК выключено по умолчанию.
+
+Включение через CLI:
+
+```bash
+secsbom run --bdu
+```
+
+Включение через переменную окружения:
+
+```bash
+export BDU=true
+secsbom run
+```
+
+При включённом BDU пайплайн:
+
+- запрашивает соответствия `CVE -> BDU ID` через `bdu.fstec.ru`
+- добавляет BDU ID в итоговый CycloneDX SBOM как свойство уязвимости
+- выводит BDU ID в экспортируемые отчёты
+
+Пример фрагмента SBOM:
+
+```json
+{
+  "id": "CVE-2023-1234",
+  "properties": [
+    {
+      "name": "ru.fstec.bdu:id",
+      "value": "BDU:2023-01813"
+    }
+  ]
+}
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,3 +138,6 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts   = "-v --tb=short"
+markers = [
+    "integration: real integration tests with external services",
+]

--- a/src/sbom_pipeline/cli.py
+++ b/src/sbom_pipeline/cli.py
@@ -153,17 +153,18 @@ def _print_help_table() -> None:
 
     # ── run options ───────────────────────────────────────────────────────────
     rt = _opts_table()
-    _opt_row(rt, "--source",          "-s", "TEXT", "Источник: local | github | gitlab",   "SOURCE",         "local")
-    _opt_row(rt, "--path",            "",   "PATH", "Путь к локальному проекту",           "PROJECT_DIR",    "examples/project_inject")
-    _opt_row(rt, "--url",             "",   "TEXT", "URL репозитория GitHub/GitLab",       "GIT_URL",        "")
-    _opt_row(rt, "--token",           "",   "TEXT", "Токен доступа (ghp_... / glpat-...)", "GIT_TOKEN",      "")
-    _opt_row(rt, "--branch",          "",   "TEXT", "Ветка репозитория",                   "GIT_BRANCH",     "HEAD")
-    _opt_row(rt, "--output-dir",      "-o", "PATH", "Директория артефактов SBOM",          "OUTPUT_DIR",     "secgensbom_out")
-    _opt_row(rt, "--reports-dir",     "",   "PATH", "Директория отчётов",                  "REPORTS_DIR",    "secgensbom_reports")
-    _opt_row(rt, "--image",           "",   "TEXT", "Docker-образ для сканирования Clair", "IMAGE_NAME",     "")
-    _opt_row(rt, "--clair-endpoint",  "",   "TEXT", "Endpoint Clair-сервера",              "CLAIR_ENDPOINT", "http://clair:8080")
-    _opt_row(rt, "--no-clair/--clair","",   "",     "Пропустить шаг Clair",               "",               "no-clair")
-    _opt_row(rt, "--verbose",         "-v", "",     "Подробный вывод (DEBUG-лог)",         "",               "false")
+    _opt_row(rt, "--source",          "-s", "TEXT", "Источник: local | github | gitlab",         "SOURCE",         "local")
+    _opt_row(rt, "--path",            "",   "PATH", "Путь к локальному проекту",                 "PROJECT_DIR",    "examples/project_inject")
+    _opt_row(rt, "--url",             "",   "TEXT", "URL репозитория GitHub/GitLab",             "GIT_URL",        "")
+    _opt_row(rt, "--token",           "",   "TEXT", "Токен доступа (ghp_... / glpat-...)",       "GIT_TOKEN",      "")
+    _opt_row(rt, "--branch",          "",   "TEXT", "Ветка репозитория",                         "GIT_BRANCH",     "HEAD")
+    _opt_row(rt, "--output-dir",      "-o", "PATH", "Директория артефактов SBOM",                "OUTPUT_DIR",     "secgensbom_out")
+    _opt_row(rt, "--reports-dir",     "",   "PATH", "Директория отчётов",                        "REPORTS_DIR",    "secgensbom_reports")
+    _opt_row(rt, "--image",           "",   "TEXT", "Docker-образ для сканирования Clair",       "IMAGE_NAME",     "")
+    _opt_row(rt, "--clair-endpoint",  "",   "TEXT", "Endpoint Clair-сервера",                    "CLAIR_ENDPOINT", "http://clair:8080")
+    _opt_row(rt, "--no-clair/--clair","",   "",     "Пропустить шаг Clair",                      "",               "no-clair")
+    _opt_row(rt, "--bdu/--no-bdu",    "",   "",     "Обогащать уязвимости идентификаторами БДУ", "BDU",            "no-bdu")
+    _opt_row(rt, "--verbose",         "-v", "",     "Подробный вывод (DEBUG-лог)",               "",               "false")
 
     examples = Table(box=None, show_header=False, padding=(0, 2), show_edge=False)
     examples.add_column()
@@ -255,6 +256,11 @@ def cmd_run(
         True, "--no-clair/--clair",
         help="Пропустить шаг Clair (по умолчанию: пропускать)",
     ),
+    use_bdu: bool = typer.Option(
+        False, "--bdu/--no-bdu",
+        help="Обогащать уязвимости идентификаторами БДУ (по умолчанию: выключено)",
+        envvar="BDU",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Подробный вывод"),
 ) -> None:
     """Полный пайплайн: генерация SBOM → сканирование → отчёты."""
@@ -276,6 +282,7 @@ def cmd_run(
     cfg.image_name = image_name or cfg.image_name
     cfg.clair_endpoint = clair_endpoint
     cfg.skip_clair = no_clair
+    cfg.use_bdu = use_bdu
     cfg.__post_init__()
 
     try:

--- a/src/sbom_pipeline/config.py
+++ b/src/sbom_pipeline/config.py
@@ -50,6 +50,9 @@ class PipelineConfig:
     # --- GitHub API ---
     github_token: Optional[str] = None
 
+    # --- Enrichment ---
+    use_bdu: bool = False
+
     # --- Производные пути (вычисляются после init) ---
     trivy_dir: Path = field(init=False)
     clair_dir: Path = field(init=False)
@@ -88,6 +91,7 @@ class PipelineConfig:
             clair_endpoint=os.getenv("CLAIR_ENDPOINT", "http://clair:8080"),
             skip_clair=os.getenv("SKIP_CLAIR", "true").lower() in ("true", "1", "yes"),
             github_token=os.getenv("GITHUB_TOKEN") or None,
+            use_bdu=os.getenv("BDU", "false").lower() in ("true", "1", "yes"),
         )
 
     def ensure_output_dirs(self) -> None:

--- a/src/sbom_pipeline/enrichters/bdu.py
+++ b/src/sbom_pipeline/enrichters/bdu.py
@@ -1,0 +1,140 @@
+"""Клиент BDU FSTEC: поиск BDU ID по списку CVE."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, Iterable
+from urllib.parse import quote, unquote
+
+import requests
+from bs4 import BeautifulSoup
+
+BDU_VUL_URL = "https://bdu.fstec.ru/vul"
+REQUEST_TIMEOUT = (10, 60)
+
+DEFAULT_HEADERS = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,"
+        "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+    ),
+    "Accept-Encoding": "gzip, deflate, br",
+    "Priority": "u=0, i",
+}
+
+
+def get_bdu_ids_by_cves(cve_ids: Iterable[str]) -> Dict[str, str]:
+    """
+    Получить соответствия CVE -> BDU-ID через bdu.fstec.ru.
+
+    Args:
+        cve_ids: список/итерируемый набор CVE идентификаторов
+
+    Returns:
+        Dict[str, str]: ключ — cve_id, значение — bdu_id
+    """
+    result: Dict[str, str] = {}
+    normalized_cves = [cve.strip() for cve in cve_ids if cve and cve.strip()]
+    if not normalized_cves:
+        return result
+
+    cookie_jar, query_token = _get_csrf_tokens()
+
+    for cve_id in normalized_cves:
+        try:
+            response = requests.get(
+                BDU_VUL_URL,
+                params={
+                    "YII_CSRF_TOKEN": quote(query_token, safe=""),
+                    "VulFilterForm[idval]": _to_bdu_search_value(cve_id),
+                        "fl": "%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D0%BD%D0%B8%D1%82%D1%8C",
+                },
+                headers=DEFAULT_HEADERS,
+                cookies=cookie_jar,
+                timeout=REQUEST_TIMEOUT,
+                verify=False,
+            )
+            response.raise_for_status()
+
+            yii_csrf_token = response.cookies.get("YII_CSRF_TOKEN")
+            phpsessid = response.cookies.get("PHPSESSID")
+            if yii_csrf_token:
+                cookie_jar["YII_CSRF_TOKEN"] = yii_csrf_token
+            if phpsessid:
+                cookie_jar["PHPSESSID"] = phpsessid
+
+            bdu_id = _extract_bdu_id(response.text)
+            if bdu_id:
+                result[cve_id] = bdu_id
+                logging.info("[bdu_client] BDU-ID найден для %s: %s", cve_id, bdu_id)
+            else:
+                logging.info("[bdu_client] BDU-ID не найден для %s", cve_id)
+
+        except requests.RequestException as exc:
+            logging.warning("[bdu_client] Ошибка запроса для %s: %s", cve_id, exc)
+
+    return result
+
+# --- Helper functions ---
+
+def _extract_query_token(cookie_token: str) -> str:
+    """
+    YII_CSRF_TOKEN обычно приходит URL-encoded и содержит токен в кавычках.
+    Пример: %22abc123%22 -> "abc123" -> abc123
+    """
+    decoded = unquote(cookie_token or "")
+    match = re.search(r'"([^"]+)"', decoded)
+    if match:
+        return match.group(1)
+    return decoded.strip('"')
+
+
+def _get_csrf_tokens() -> tuple[Dict[str, str], str]:
+    response = requests.get(
+        BDU_VUL_URL,
+        timeout=REQUEST_TIMEOUT,
+        verify=False,
+        headers=DEFAULT_HEADERS,
+    )
+    response.raise_for_status()
+    cookie_jar: Dict[str, str] = {}
+
+    yii_csrf_token = response.cookies.get("YII_CSRF_TOKEN")
+    phpsessid = response.cookies.get("PHPSESSID")
+    if yii_csrf_token:
+        cookie_jar["YII_CSRF_TOKEN"] = yii_csrf_token
+    if phpsessid:
+        cookie_jar["PHPSESSID"] = phpsessid
+
+    cookie_token = response.cookies.get("YII_CSRF_TOKEN") or cookie_jar.get("YII_CSRF_TOKEN")
+    if not cookie_token:
+        raise RuntimeError("Не найден cookie YII_CSRF_TOKEN")
+
+    query_token = _extract_query_token(cookie_token)
+    if not query_token:
+        raise RuntimeError("Не удалось извлечь query_token из YII_CSRF_TOKEN")
+
+    return cookie_jar, query_token
+
+def _extract_bdu_id(html: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    nodes = soup.select("#vuls a.confirm-vul")
+    if len(nodes) != 1:
+        return None
+
+    bdu_id = nodes[0].get_text(strip=True)
+    return bdu_id or None
+
+
+def _to_bdu_search_value(cve_id: str) -> str:
+    """Преобразовать CVE ID в формат поиска BDU: без префикса ``CVE-``."""
+    normalized = cve_id.strip()
+    if normalized.upper().startswith("CVE-"):
+        return normalized[4:]
+    return normalized

--- a/src/sbom_pipeline/exporter.py
+++ b/src/sbom_pipeline/exporter.py
@@ -44,6 +44,8 @@ _VULN_COLUMNS = [
     "Сканер",
     "Исправлено в версии",
 ]
+_BDU_VULN_COLUMN = "BDU / ID"
+_SEVERITY_COLUMN = "Критичность"
 
 # Цвета критичности для Word
 _SEVERITY_COLORS: Dict[str, RGBColor] = {
@@ -61,10 +63,12 @@ class Exporter:
         dependencies: list,
         vulns: Optional[List[VulnFinding]] = None,
         sbom_path: Optional[str] = None,
+        include_bdu: bool = False,
     ) -> None:
         self.deps = dependencies
         self.vulns: List[VulnFinding] = vulns or []
         self.sbom_path = sbom_path
+        self.include_bdu = include_bdu
         logging.info(
             f"Exporter: {len(self.deps)} зависимостей, {len(self.vulns)} уязвимостей"
         )
@@ -77,13 +81,14 @@ class Exporter:
         path = Path(report)
         path.parent.mkdir(parents=True, exist_ok=True)
         try:
+            vuln_columns = self._vuln_columns()
             with pd.ExcelWriter(str(path), engine="openpyxl") as writer:
                 # Лист 1: Компоненты
                 comp_df = pd.DataFrame(self._comp_rows(), columns=_COMP_COLUMNS)
                 comp_df.to_excel(writer, index=False, sheet_name="Компоненты")
 
                 # Лист 2: Уязвимости
-                vuln_df = pd.DataFrame(self._vuln_rows(), columns=_VULN_COLUMNS)
+                vuln_df = pd.DataFrame(self._vuln_rows(), columns=vuln_columns)
                 vuln_df.to_excel(writer, index=False, sheet_name="Уязвимости")
 
             self._write_sig(path)
@@ -122,10 +127,11 @@ class Exporter:
             # --- Таблица уязвимостей ---
             if self.vulns:
                 doc.add_heading("Уязвимости", level=2)
+                vuln_columns = self._vuln_columns()
                 vuln_rows = self._vuln_rows()
-                vt = doc.add_table(rows=1 + len(vuln_rows), cols=len(_VULN_COLUMNS))
+                vt = doc.add_table(rows=1 + len(vuln_rows), cols=len(vuln_columns))
                 vt.style = "Table Grid"
-                for i, col in enumerate(_VULN_COLUMNS):
+                for i, col in enumerate(vuln_columns):
                     cell = vt.rows[0].cells[i]
                     cell.text = col
                     for run in cell.paragraphs[0].runs:
@@ -136,7 +142,7 @@ class Exporter:
                         cell = vt.rows[r_idx].cells[c_idx]
                         cell.text = str(val)
                         # Подсветка критичности
-                        if c_idx == 4:  # Критичность
+                        if vuln_columns[c_idx] == _SEVERITY_COLUMN:
                             color = _SEVERITY_COLORS.get(str(val).upper(), _SEVERITY_COLORS["UNKNOWN"])
                             for run in cell.paragraphs[0].runs:
                                 run.font.color.rgb = color
@@ -174,7 +180,14 @@ class Exporter:
             # --- Таблица уязвимостей ---
             if self.vulns:
                 doc.text.addElement(P(text="Уязвимости", stylename=title_style))
-                doc.text.addElement(self._make_odt_table("SBOM_Vulns", _VULN_COLUMNS, self._vuln_rows(), cell_style))
+                doc.text.addElement(
+                    self._make_odt_table(
+                        "SBOM_Vulns",
+                        self._vuln_columns(),
+                        self._vuln_rows(),
+                        cell_style,
+                    )
+                )
 
             doc.save(str(path))
             self._write_sig(path)
@@ -203,9 +216,16 @@ class Exporter:
             })
         return rows
 
+    def _vuln_columns(self) -> List[str]:
+        columns = list(_VULN_COLUMNS)
+        if self.include_bdu:
+            columns.insert(3, _BDU_VULN_COLUMN)
+        return columns
+
     def _vuln_rows(self) -> List[Dict[str, Any]]:
-        return [
-            {
+        rows: List[Dict[str, Any]] = []
+        for v in self.vulns:
+            row: Dict[str, Any] = {
                 _VULN_COLUMNS[0]: v.component_name,
                 _VULN_COLUMNS[1]: v.component_version,
                 _VULN_COLUMNS[2]: v.cve_id,
@@ -215,8 +235,12 @@ class Exporter:
                 _VULN_COLUMNS[6]: v.scanner,
                 _VULN_COLUMNS[7]: v.fixed_version,
             }
-            for v in self.vulns
-        ]
+            if self.include_bdu:
+                items = list(row.items())
+                items.insert(3, (_BDU_VULN_COLUMN, v.bdu_id or ""))
+                row = dict(items)
+            rows.append(row)
+        return rows
 
     @staticmethod
     def _make_odt_table(

--- a/src/sbom_pipeline/pipeline.py
+++ b/src/sbom_pipeline/pipeline.py
@@ -115,7 +115,11 @@ def run(cfg: PipelineConfig) -> None:
         sbom_data: Dict[str, Any] = json.load(f)
 
     if all_findings:
-        sbom_data = merge_vulns_into_sbom(sbom_data, all_findings)
+        sbom_data = merge_vulns_into_sbom(
+            sbom_data,
+            all_findings,
+            enable_bdu=cfg.use_bdu,
+        )
         SbomHandler.write_json(sbom_data, signed_bom)
 
         # Сохранить нормализованный vuln-dump
@@ -171,7 +175,12 @@ def _export_reports(
         d.mkdir(parents=True, exist_ok=True)
 
     deps = _extract_dependencies(sbom_data, str(cfg.output_dir / SIGNED_BOM_FILE))
-    exporter = Exporter(deps, vulns=vulns, sbom_path=str(cfg.output_dir / SIGNED_BOM_FILE))
+    exporter = Exporter(
+        deps,
+        vulns=vulns,
+        sbom_path=str(cfg.output_dir / SIGNED_BOM_FILE),
+        include_bdu=cfg.use_bdu,
+    )
 
     exporter.exportToExcel(str(excel_dir / f"{stem}{EXCEL_EXTENSION}"))
     exporter.exportToDocx(str(docx_dir / f"{stem}{DOCX_EXTENSION}"))

--- a/src/sbom_pipeline/vuln_merger.py
+++ b/src/sbom_pipeline/vuln_merger.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import copy
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+from sbom_pipeline.enrichters import bdu
 
 
 @dataclass
@@ -23,6 +25,7 @@ class VulnFinding:
     description: str
     scanner: str           # trivy | clair | dependency-check
     fixed_version: str = ""
+    bdu_id: Optional[str] = None  # Внутренний ID от BDU, если есть
 
     @property
     def severity_upper(self) -> str:
@@ -32,6 +35,7 @@ class VulnFinding:
 def merge_vulns_into_sbom(
     sbom: Dict[str, Any],
     findings: List[VulnFinding],
+    enable_bdu: bool = False,
 ) -> Dict[str, Any]:
     """
     Встроить список VulnFinding в SBOM как массив «vulnerabilities»
@@ -53,6 +57,11 @@ def merge_vulns_into_sbom(
             comp_index[purl] = bom_ref
         comp_index[f"{name}@{version}"] = bom_ref
 
+    bdu_by_cve_index: Dict[str, str] = {}
+    if enable_bdu:
+        findings_list: list[str] = [f.cve_id for f in findings]
+        bdu_by_cve_index = bdu.get_bdu_ids_by_cves(findings_list)
+
     vulns: list[Dict[str, Any]] = []
     for f in findings:
         ref = (
@@ -60,6 +69,9 @@ def merge_vulns_into_sbom(
             or comp_index.get(f"{f.component_name}@{f.component_version}")
             or f"{f.component_name}@{f.component_version}"
         )
+
+        if enable_bdu and bdu_by_cve_index:
+            f.bdu_id = bdu_by_cve_index.get(f.cve_id)
 
         entry: Dict[str, Any] = {
             "id": f.cve_id,
@@ -74,6 +86,13 @@ def merge_vulns_into_sbom(
             "description": f.description,
             "affects": [{"ref": ref}],
         }
+        if f.bdu_id:
+            entry["properties"] = [
+                {
+                    "name": "ru.fstec.bdu:id",
+                    "value": f.bdu_id,
+                }
+            ]
         if f.fixed_version:
             entry["recommendation"] = f"Обновить до версии {f.fixed_version}"
 
@@ -90,6 +109,7 @@ def save_vuln_report(findings: List[VulnFinding], path: Path) -> None:
     data = [
         {
             "cve_id": f.cve_id,
+            "bdu_id": f.bdu_id,
             "component": f.component_name,
             "version": f.component_version,
             "purl": f.component_purl,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/integration/sbom_pipeline/enrichters/test_bdu_integration.py
+++ b/tests/integration/sbom_pipeline/enrichters/test_bdu_integration.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import os
+import sys
+
+import pytest
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
+
+ROOT = Path(__file__).resolve().parents[4]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sbom_pipeline.enrichters import bdu
+
+
+urllib3.disable_warnings(InsecureRequestWarning)
+
+pytestmark = pytest.mark.integration
+
+
+def _known_cve() -> str:
+    return os.getenv("BDU_TEST_CVE", "CVE-2026-24017")
+
+
+def _expected_bdu_id() -> str:
+    expected_bdu_id = os.getenv("BDU_EXPECTED_ID", "BDU:2026-03213")
+    if not expected_bdu_id:
+        pytest.skip("Set BDU_EXPECTED_ID to run strict BDU integration assertions")
+    return expected_bdu_id
+
+
+@pytest.mark.skipif(
+    os.getenv("BDU_INTEGRATION") != "1",
+    reason="Set BDU_INTEGRATION=1 to run real BDU integration tests",
+)
+def test_get_bdu_ids_by_cves_returns_expected_mapping_for_known_cve():
+    cve_id = _known_cve()
+    expected_bdu_id = _expected_bdu_id()
+
+    result = bdu.get_bdu_ids_by_cves([cve_id])
+
+    assert result == {cve_id: expected_bdu_id}
+
+
+@pytest.mark.skipif(
+    os.getenv("BDU_INTEGRATION") != "1",
+    reason="Set BDU_INTEGRATION=1 to run real BDU integration tests",
+)
+def test_get_bdu_ids_by_cves_skips_unknown_cve():
+    known_cve_id = _known_cve()
+    expected_bdu_id = _expected_bdu_id()
+    unknown_cve_id = "CVE-2099-99999"
+
+    result = bdu.get_bdu_ids_by_cves([known_cve_id, unknown_cve_id])
+
+    assert result[known_cve_id] == expected_bdu_id
+    assert unknown_cve_id not in result
+    assert len(result) == 1
+
+
+@pytest.mark.skipif(
+    os.getenv("BDU_INTEGRATION") != "1",
+    reason="Set BDU_INTEGRATION=1 to run real BDU integration tests",
+)
+def test_get_bdu_ids_by_cves_filters_blank_values_and_unknowns():
+    known_cve_id = _known_cve()
+    expected_bdu_id = _expected_bdu_id()
+    unknown_cve_id = "CVE-2099-99999"
+
+    result = bdu.get_bdu_ids_by_cves(["", "   ", known_cve_id, unknown_cve_id])
+
+    assert result == {known_cve_id: expected_bdu_id}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6,9 +6,13 @@ import json
 import tempfile
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from sbom_pipeline import cli
 from sbom_pipeline import __version__
 from sbom_pipeline.config import PipelineConfig
 from sbom_pipeline.dedup import dedup_sbom
+from sbom_pipeline.exporter import Exporter
 from sbom_pipeline.sign import sign_sbom, verify_sbom
 from sbom_pipeline.vuln_merger import VulnFinding, merge_vulns_into_sbom
 
@@ -26,6 +30,8 @@ _MINIMAL_SBOM: dict = {
     ],
 }
 
+_CLI_RUNNER = CliRunner()
+
 
 # ---------------------------------------------------------------------------
 # Version
@@ -41,10 +47,47 @@ def test_version_is_semver():
 # Config
 # ---------------------------------------------------------------------------
 
+def test_cli_no_bdu_overrides_bdu_env(monkeypatch):
+    captured: dict[str, bool] = {}
+
+    def fake_pipeline_run(cfg: PipelineConfig) -> None:
+        captured["use_bdu"] = cfg.use_bdu
+
+    monkeypatch.setenv("BDU", "true")
+    monkeypatch.setattr(cli, "pipeline_run", fake_pipeline_run)
+    monkeypatch.setattr(cli, "_print_banner", lambda: None)
+    monkeypatch.setattr(cli, "_print_footer", lambda: None)
+    monkeypatch.setattr(cli, "setup_logging", lambda verbose: None)
+
+    result = _CLI_RUNNER.invoke(cli.app, ["run", "--no-bdu"])
+
+    assert result.exit_code == 0
+    assert captured["use_bdu"] is False
+
+
+def test_cli_bdu_enables_use_bdu(monkeypatch):
+    captured: dict[str, bool] = {}
+
+    def fake_pipeline_run(cfg: PipelineConfig) -> None:
+        captured["use_bdu"] = cfg.use_bdu
+
+    monkeypatch.delenv("BDU", raising=False)
+    monkeypatch.setattr(cli, "pipeline_run", fake_pipeline_run)
+    monkeypatch.setattr(cli, "_print_banner", lambda: None)
+    monkeypatch.setattr(cli, "_print_footer", lambda: None)
+    monkeypatch.setattr(cli, "setup_logging", lambda verbose: None)
+
+    result = _CLI_RUNNER.invoke(cli.app, ["run", "--bdu"])
+
+    assert result.exit_code == 0
+    assert captured["use_bdu"] is True
+
+
 def test_config_defaults():
     cfg = PipelineConfig()
     assert cfg.source == "local"
     assert cfg.skip_clair is True
+    assert cfg.use_bdu is False
     assert cfg.project_dir == Path("examples/project_inject")
 
 
@@ -52,10 +95,12 @@ def test_config_from_env(monkeypatch):
     monkeypatch.setenv("SOURCE", "github")
     monkeypatch.setenv("GIT_URL", "https://github.com/org/repo")
     monkeypatch.setenv("SKIP_CLAIR", "false")
+    monkeypatch.setenv("BDU", "true")
     cfg = PipelineConfig.from_env()
     assert cfg.source == "github"
     assert cfg.git_url == "https://github.com/org/repo"
     assert cfg.skip_clair is False
+    assert cfg.use_bdu is True
 
 
 # ---------------------------------------------------------------------------
@@ -130,5 +175,100 @@ def test_merge_vulns_into_sbom():
         )
     ]
     result = merge_vulns_into_sbom(sbom, findings)
+    vulnerability = result["vulnerabilities"][0]
+
     assert "vulnerabilities" in result
-    assert result["vulnerabilities"][0]["id"] == "CVE-2023-1234"
+    assert vulnerability["id"] == "CVE-2023-1234"
+    assert "properties" not in vulnerability
+
+
+
+def test_merge_vulns_with_bdu_into_sbom():
+    sbom = json.loads(json.dumps(_MINIMAL_SBOM))
+    findings = [
+        VulnFinding(
+            cve_id="CVE-2023-1234",
+            bdu_id="BDU:2023-01813",
+            scanner="trivy",
+            component_name="requests",
+            component_version="2.31.0",
+            component_purl="pkg:pypi/requests@2.31.0",
+            severity="HIGH",
+            cvss_score=7.5,
+            description="Test vuln",
+            fixed_version="2.32.0",
+        )
+    ]
+    result = merge_vulns_into_sbom(sbom, findings)
+    vulnerability = result["vulnerabilities"][0]
+
+    assert "vulnerabilities" in result
+    assert vulnerability["id"] == "CVE-2023-1234"
+    assert vulnerability["properties"] == [
+        {"name": "ru.fstec.bdu:id", "value": "BDU:2023-01813"}
+    ]
+
+
+def test_exporter_hides_bdu_column_when_disabled():
+    findings = [
+        VulnFinding(
+            cve_id="CVE-2023-1234",
+            bdu_id="BDU:2023-01813",
+            scanner="trivy",
+            component_name="requests",
+            component_version="2.31.0",
+            component_purl="pkg:pypi/requests@2.31.0",
+            severity="HIGH",
+            cvss_score=7.5,
+            description="Test vuln",
+            fixed_version="2.32.0",
+        )
+    ]
+
+    exporter = Exporter([], vulns=findings)
+    vuln_rows = exporter._vuln_rows()
+
+    assert exporter._vuln_columns() == [
+        "Компонент",
+        "Версия",
+        "CVE / ID",
+        "CVSS",
+        "Критичность",
+        "Описание",
+        "Сканер",
+        "Исправлено в версии",
+    ]
+    assert "BDU / ID" not in vuln_rows[0]
+
+
+def test_exporter_shows_bdu_column_when_enabled():
+    findings = [
+        VulnFinding(
+            cve_id="CVE-2023-1234",
+            bdu_id="BDU:2023-01813",
+            scanner="trivy",
+            component_name="requests",
+            component_version="2.31.0",
+            component_purl="pkg:pypi/requests@2.31.0",
+            severity="HIGH",
+            cvss_score=7.5,
+            description="Test vuln",
+            fixed_version="2.32.0",
+        )
+    ]
+
+    exporter = Exporter([], vulns=findings, include_bdu=True)
+    vuln_rows = exporter._vuln_rows()
+
+    assert exporter._vuln_columns() == [
+        "Компонент",
+        "Версия",
+        "CVE / ID",
+        "BDU / ID",
+        "CVSS",
+        "Критичность",
+        "Описание",
+        "Сканер",
+        "Исправлено в версии",
+    ]
+    assert vuln_rows[0]["BDU / ID"] == "BDU:2023-01813"

--- a/tests/unit/sbom_pipeline/enrichters/html.html
+++ b/tests/unit/sbom_pipeline/enrichters/html.html
@@ -1,0 +1,3969 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="/themes/fstec/css/datepicker/bootstrap-datepicker.css" />
+<link rel="stylesheet" type="text/css" href="/themes/fstec/css/select2/select2.css" />
+<link rel="stylesheet" type="text/css" href="/assets/d68f76a4/listview/styles.css" />
+<script type="text/javascript" src="/js/jquery.min.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/datepicker/bootstrap-datepicker.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/datepicker/locales/bootstrap-datepicker.ru.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/cookie/jquery.cookie.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/select2/select2.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/select2/select2_locale_ru.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/ubi/vul/index.js"></script>
+<script type="text/javascript" src="/assets/79fc5d5a/jquery.ba-bbq.min.js"></script>
+<script type="text/javascript" src="/assets/79fc5d5a/jquery.yiiactiveform.js"></script>
+<title>БДУ - Уязвимости</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name='yandex-verification' content='6e77e36010cdf1ed' />
+    <meta name="base-url" content=""/>
+    <link rel="stylesheet" href="/themes/fstec/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/themes/fstec/css/style.css">
+
+
+    <!--[if lt IE 9]>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <script src="/themes/fstec/js/html5shiv.js"></script>
+        <script src="/themes/fstec/js/respond.min.js"></script>
+    <![endif]-->
+    <style>
+        .preloader {
+            position: fixed;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            background-image: radial-gradient(#ffffff, #757575);
+            opacity: 0.6;
+            z-index: 1001;
+        }
+        .preloader__row {
+            position: relative;
+            top: 50%;
+            left: 50%;
+            width: 34px;
+            height: 34px;
+            margin-top: -17px;
+            margin-left: -17px;
+            background-color: #ffffff;
+            background-repeat: no-repeat;
+            background-image: url('/themes/fstec/images/loading.gif');
+            opacity: 1;
+        }
+        .loaded_hiding .preloader {
+            transition: 0.3s opacity;
+            opacity: 0;
+        }
+        .loaded .preloader {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="preloader">
+      <div class="preloader__row">
+        <div class="preloader__item"></div>
+      </div>
+    </div> 
+    <div id="wrap">
+
+    
+        <div class="page-header litegray-gradient">
+            <div class="row inner">
+                <div class="col-md-2 col-lg-2 visible-md visible-lg text-center ">
+                    <a href="http://fstec.ru" target="_blank" rel="noopener noreferrer" title=""><img class="fstec" src="/themes/fstec/css/images/fstec.png" alt='&laquo;ФСТЭК России&raquo;'></a>
+                </div>
+                <div class="col-md-8 col-lg8 text-center">
+                                            <h1>Банк данных угроз безопасности информации</h1>
+                    
+                    <div class="row text-center">
+                        <div class="col-lg-6 text-left visible-md visible-lg">
+                            <h4>Федеральная служба по техническому и экспортному контролю</h4>
+                            <h4><small>ФСТЭК России</small></h4>
+                        </div>
+                        <div class="col-lg-6 text-left visible-md visible-lg">
+                            <h4>Государственный научно-исследовательский испытательный институт проблем технической защиты информации</h4>
+                            <h4><small>ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;</small></h4>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2 col-lg-2 visible-md visible-lg text-center">
+                    <img class="gniii" src="/themes/fstec/css/images/gniii.png" alt='ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;'>
+                </div>
+            </div>
+        </div>
+                <div class="nav-wrapper">
+            <nav id="top-nav" class="navbar navbar-inverse" role="navigation">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#top-menu">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+
+                <div class="collapse navbar-collapse" id="top-menu">
+                                        <ul class="nav navbar-nav" id="menu">
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/threat">Угрозы <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/threat">Перечень угроз</a></li>
+<li><a href="/threat-section">Новый раздел угроз</a></li>
+<li><a href="/threat/ai">Угрозы ИИ</a></li>
+</ul>
+</li>
+<li class="dropdown active"><a class="dropdown-toggle" data-toggle="dropdown" href="/vul">Уязвимости <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li class="active"><a href="/vul">Список уязвимостей</a></li>
+<li><a href="/webvulns">Типовые уязвимости веб-приложений</a></li>
+<li><a href="/vul/danger">Наиболее опасные уязвимости</a></li>
+<li><a href="/vul/ai">Уязвимости в ПО для разработки ИИ</a></li>
+<li><a href="/charts">Инфографика</a></li>
+<li><a href="/calc">Калькулятор CVSS V2</a></li>
+<li><a href="/calc3">Калькулятор CVSS V3</a></li>
+<li><a href="/calc31">Калькулятор CVSS V3.1</a></li>
+<li><a href="/calc4">Калькулятор CVSS V4</a></li>
+<li><a href="/scanoval">ScanOVAL</a></li>
+<li><a href="/scanovalforlinux">ScanOVAL для Linux</a></li>
+<li><a href="/software-section/bducpe">Каталог ПО</a></li>
+</ul>
+</li>
+<li title="Результаты тестирования обновлений ПО"><a href="/software-section/updates">Тестирование обновлений</a></li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/documents">Документы <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/terms">Термины</a></li>
+<li><a href="/regulations">Регламент включения уязвимостей</a></li>
+<li><a href="/documents">Все документы</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/contacts/sendmail">Обратная связь<span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/contacts/sendmail">Написать администратору</a></li>
+<li><a href="/contacts/email">Электронная почта</a></li>
+<li><a href="/contacts/vulreport">Сообщить об уязвимости</a></li>
+<li><a href="/contacts/threatreport">Сообщить об угрозе</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/news/summary">Обновления <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/news/summary">Новости сайта</a></li>
+<li><a href="/feed">Список каналов (RSS, Atom)</a></li>
+<li><a target="window" rel="noopener noreferrer" href="https://t.me/bdufstecru">Telegram</a></li>
+<li><a target="window" rel="noopener noreferrer" href="https://max.ru/id3666088317_gos">MAX</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/site/partners">Участники <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/partners">Организации</a></li>
+<li><a href="/contacts/vulreport/list">Исследователи</a></li>
+<li><a href="/rating">Рейтинг исследователей</a></li>
+</ul>
+</li>
+<li title="Обучение"><a href="/education">Обучение</a></li>
+<li title="Банк данных угроз АСУ ТП"><a target="_blank" rel="noopener noreferrer" href="https://bduasutp.fstec.ru">БДУ АСУ ТП</a></li>
+<li title="Официальный сайт ФСТЭК России"><a target="_blank" rel="noopener noreferrer" href="http://fstec.ru">ФСТЭК России</a></li>
+</ul>                    
+                                            <div class="row">
+                            <div class="col-xs-12 col-sm-3 col-md-3 pull-right">
+
+                                <form action="/search" class="form-control-static" role="search">
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" placeholder="Поиск" name="q">
+                                        <div class="input-group-btn">
+                                            <button class="btn btn-default" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+                                        </div>
+                                    </div>
+                                </form>
+
+                            </div>
+                        </div>
+                                </nav>
+        </div>
+                <div class="container-fluid">
+
+                            <ol class="breadcrumb">
+<li><a href="/">Главная</a></li><li>Список уязвимостей</li></ol><!-- breadcrumbs -->
+                        <div class="row">
+                    <div class="col-sm-12 col-md-6 col-lg-6 col-md-push-3 col-lg-push-3">
+        
+<!--div class="row">
+    <div class="context-search input-group col-sm-3 col-sm-offset-9" title="Контекстный поиск по названиям уязвимостей">
+        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
+        <input type="text" id="search" name="search" class="form-control input-sm"/>
+    </div>
+</div-->
+
+<!--  -->
+    <!-- <h4>По Вашему запросу найдено <strong>1</strong> записей</h4> -->
+<!--  -->
+
+<div id="vuls" class="list-view">
+&nbsp;<div class="btn-group"><button class="btn btn-default btn-xs dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">Сортировка: <span class="caret"></span></button><ul class="dropdown-menu" role="menu" id="yw0">
+<li class="active"><a href="/vul?sort=identifier">по идентификатору</a></li>
+<li><a href="/vul?sort=datv">по выявлению</a></li>
+<li><a href="/vul?sort=bsc">по критичности</a></li>
+</ul></div>
+<div class="sizer pull-left btn-toolbar">Выводить по: 10, <a href="/vul?size=20">20</a>, <a href="/vul?size=50">50</a>, <a href="/vul?size=100">100</a></div>
+<div class="summary pull-right hidden-xs">Элементы с 1 по 1 из 1</div>
+<div class="clearfix"></div><table class="table table-striped table-vuls">
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03213">BDU:2026-03213</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость межсетевого экрана веб-приложений Fortinet FortiWeb связана с недостаточным контролем за частотой взаимодействий. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, обойти ограничение на количество попыток аутентификации  с помощью специально созданных запросов">Уязвимость межсетевого экрана веб-приложений Fortinet FortiWeb, связанная с недостаточным контролем за частотой взаимодействий, позволяющая нарушителю обойти ограничение на количество попыток аутентификации</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>10.03.2026</span></span>
+		</div>
+    </td>
+</tr>
+</table>
+<div class="keys" style="display:none" title="/vul"><span>95156</span></div>
+</div>
+            <div class="row">
+            <div class="col-sm-12 text-center">
+                                <p><a href="/files/documents/vullist.xlsx">Скачать сведения об уязвимостях в формате XLSX</a></p>
+            </div>
+        </div>
+    
+    
+    <div class="row">
+        <div class="col-sm-12 text-center">
+                                            <p><a href="/files/documents/vulxml.zip">Скачать сведения об уязвимостях в формате XML</a></p>
+        </div>
+    </div>
+
+        </div><!-- content -->
+    <div class="col-sm-12 col-md-3 col-lg-3 col-md-pull-6 col-lg-pull-6">
+        <div class="portlet" id="yw2">
+<div class="portlet-decoration">
+<div class="portlet-left-decoration-inner">
+<div class="portlet-title">Фильтрация</div>
+</div>
+</div>
+<div class="portlet-content">
+<form role="form" id="vul-filter-form" action="/vul" method="post">
+<input type="hidden" value="ZVFrWVh4MnJxR1Fhfl9vc1J6TEEyNk4xaEplbDlyU3jK2Hxs0DdvkNmsyepmVc2BgVYQHlokUoNY0adwOpG2KQ==" name="YII_CSRF_TOKEN" /><div class="form-group">
+    <label for="search">Контекстный поиск по названию уязвимости</label>
+    <div class="context-search input-group" title="">
+        <!--Далее с фиксом input-group-addon для chrome-->
+        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span><input type="text"
+                                                                                                      id="search"
+                                                                                                      name="search"
+                                                                                                      class="form-control input-sm"
+                                                                                                      placeholder="Введите слово или словосочетание"
+                                                                                                      value=""/>
+    </div>
+</div>
+
+
+<div id="vul-filter-form_es_" class="errorSummary" style="display:none"><p>Необходимо исправить следующие ошибки:</p>
+<ul><li>dummy</li></ul></div><div class="form-group">
+    <label for="VulFilterForm_vendor">Производитель ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                         data-toggle="popover"
+                                                         data-content="Компания (организация) - производитель (разработчик) программного обеспечения в котором обнаружена уязвимость"></span>
+    <input name="VulFilterForm[vendor]" id="VulFilterForm_vendor" type="hidden" />    <div class="errorMessage" id="VulFilterForm_vendor_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_softType">Тип ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                           data-toggle="popover"
+                                                           data-content="Тип программного обеспечения, в котором обнаружена уязвимость"></span>
+    <select name="VulFilterForm[softType]" id="VulFilterForm_softType">
+<option value=""></option>
+<option value="1">Операционная система</option>
+<option value="2">СУБД</option>
+<option value="3">Средство защиты</option>
+<option value="8">&nbsp;&nbsp;Программное средство защиты</option>
+<option value="9">&nbsp;&nbsp;ПО программно-аппаратных средств защиты</option>
+<option value="4">Сетевое средство</option>
+<option value="10">&nbsp;&nbsp;Сетевое программное средство</option>
+<option value="11">&nbsp;&nbsp;ПО сетевого программно-аппаратного средства</option>
+<option value="5">Прикладное ПО информационных систем</option>
+<option value="6">Средство АСУ ТП</option>
+<option value="12">&nbsp;&nbsp;Программное средство АСУ ТП</option>
+<option value="13">&nbsp;&nbsp;ПО программно-аппаратного средства АСУ ТП</option>
+<option value="7">ПО виртуализации/ПО виртуального программно-аппаратного средства</option>
+<option value="15">Микропрограммный код аппаратных компонент компьютера</option>
+<option value="16">Микропрограммный код</option>
+<option value="19">ПО программно-аппаратного средства</option>
+<option value="20">ПО для разработки ИИ</option>
+<option value="unknown">"Не определен"</option>
+</select>    <div class="errorMessage" id="VulFilterForm_softType_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_soft">Программное обеспечение</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                       data-toggle="popover"
+                                                       data-content="Наименование программного обеспечения, в котором обнаружена уязвимость"></span>
+        <input name="VulFilterForm[soft]" id="VulFilterForm_soft" type="hidden" />    <div class="errorMessage" id="VulFilterForm_soft_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_platf">Аппаратная платформа</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                        data-toggle="popover"
+                                                        data-content="Аппаратная платформа, при установке на которой программное обеспечение содержит уязвимость"></span>
+    <select name="VulFilterForm[platf]" id="VulFilterForm_platf">
+<option value=""></option>
+<option value="-1">Не указана</option>
+<option value="1">x86 (x32 / IA-32)</option>
+<option value="2">64-bit</option>
+<option value="3">SPARCv8</option>
+<option value="5">ESA/390</option>
+<option value="6">z/Architecture</option>
+<option value="7">PowerPC</option>
+<option value="9">Alpha</option>
+<option value="10">IA-64 (Itanium)</option>
+<option value="12">MIPS</option>
+<option value="13">MIPS32</option>
+<option value="14">32-bit</option>
+<option value="16">Supervisor Engine</option>
+<option value="17">MIPS64</option>
+<option value="18">CPU 1211C</option>
+<option value="19">ARM</option>
+<option value="20">iPhone</option>
+<option value="21">iPad</option>
+<option value="22">VMWare vSphere</option>
+<option value="23">SPARC</option>
+<option value="24">s390</option>
+<option value="25">ARM7</option>
+<option value="26">ARM64</option>
+<option value="27">zSeries</option>
+<option value="28">AS/400</option>
+<option value="29">eServer iSeries</option>
+<option value="30">System i</option>
+<option value="31">System Z</option>
+<option value="32">платформа уточняется</option>
+<option value="33">Power</option>
+<option value="34">PA-RISC (64-bit)</option>
+<option value="35">ROMP</option>
+<option value="36">PS/2</option>
+<option value="37">System/370</option>
+<option value="38">iPod</option>
+<option value="39">IA-32</option>
+<option value="40">DEC Alpha</option>
+<option value="41">AVR32</option>
+<option value="42">Itanium</option>
+<option value="43">PA-RISC</option>
+<option value="44">68k</option>
+<option value="45">SH3</option>
+<option value="46">VAX</option>
+<option value="47">SPARC64</option>
+<option value="48">ARMel</option>
+<option value="49">ARMhf</option>
+<option value="50">MIPSel</option>
+<option value="51">s390x</option>
+<option value="52">Power Architecture</option>
+<option value="53">Cisco ISE</option>
+<option value="57">Nexus 7</option>
+<option value="58">Nexus</option>
+<option value="59">Android One</option>
+<option value="60">Nexus 5X</option>
+<option value="61">Nexus 9</option>
+<option value="63">Nexus 6P</option>
+<option value="64">Pixel C</option>
+<option value="65">Nexus 6</option>
+<option value="66">Nexus 5</option>
+<option value="67">Cisco ASA 5500 Series Adaptive Security Appliances</option>
+<option value="68">Cisco ASA 5500-X Series Next-Generation Firewalls</option>
+<option value="69">Cisco ASA Services Module for Cisco Catalyst 6500 Series Switches and Cisco 7600 Series Routers</option>
+<option value="70">Cisco ASA 1000V Cloud Firewall</option>
+<option value="71">Cisco Adaptive Security Virtual Appliance (ASAv)</option>
+<option value="72">Cisco Firepower 4100 Series</option>
+<option value="73">Cisco Firepower 9300 ASA Security Module</option>
+<option value="74">Cisco Firepower Threat Defense Software</option>
+<option value="75">Cisco Firewall Services Module</option>
+<option value="76">Cisco Industrial Security Appliance 3000</option>
+<option value="77">Cisco PIX Firewalls</option>
+<option value="80">ARM32</option>
+<option value="84">IBM</option>
+<option value="85">Nexus Player</option>
+<option value="86">Pixel XL</option>
+<option value="87">Plxel</option>
+<option value="88">Android</option>
+<option value="89">Nexus 10</option>
+<option value="90">Exynos AP</option>
+<option value="91">Intel NUC 6-gen</option>
+<option value="92">Zaurus</option>
+<option value="93">Motorola 68k</option>
+<option value="94">Linux</option>
+<option value="95">SRX 210</option>
+<option value="96">SRX 240</option>
+<option value="97">SRX 650</option>
+<option value="98">SSG-5</option>
+<option value="99">SSG-20</option>
+<option value="100">MP70</option>
+<option value="101">oMG500</option>
+<option value="102">oMG2000</option>
+<option value="103">MG90</option>
+<option value="104">FX30</option>
+<option value="105">WP76xx</option>
+<option value="106">WP85xx</option>
+<option value="107">UAP-AC-Lite/LR/Pro/EDU/M/M-PRO/IW/IW-Pro</option>
+<option value="108">UAP-AC-HD/SHD</option>
+<option value="109">UAP-LR</option>
+<option value="110">UAP-OD</option>
+<option value="111">UAP-OD5</option>
+<option value="112">UAP-v2</option>
+<option value="113">UAP-LR-v2</option>
+<option value="114">UAP-IW</option>
+<option value="115">UAP-Pro</option>
+<option value="117">US-L2-POE</option>
+<option value="118">US-16-XG</option>
+<option value="119">Itanium-Based</option>
+<option value="120">Cisco ASR 1000</option>
+<option value="121">Cisco cBR-8</option>
+<option value="122">Cisco 5760 WLC</option>
+<option value="123">Cisco Catalyst 4500E Supervisor Engine 8-E</option>
+<option value="124">Cisco NGWC 3850</option>
+<option value="126">MediaTek M-ALPS03353876</option>
+<option value="127">MediaTek M-ALPS03353861</option>
+<option value="128">MediaTek M-ALPS03353869</option>
+<option value="129">MediaTek M-ALPS03353867</option>
+<option value="130">MediaTek M-ALPS03353872</option>
+<option value="131">Broadcom B-V2017063001</option>
+<option value="132">Broadcom BCM4355C0 9.44.78.27.0.1.56</option>
+<option value="133">Broadcom BCM4355C0 9.44.78.27.0.1.57</option>
+<option value="134">Avaya Fabric Connect Virtual Services Platform 8000</option>
+<option value="135">Avaya Fabric Connect Virtual Services Platform7200</option>
+<option value="136">Avaya Fabric Connect Virtual Services Platform 4000</option>
+<option value="137">Cisco ASR 5000</option>
+<option value="138">Cisco ASR 5500</option>
+<option value="139">Cisco ASR 5700</option>
+<option value="144">Sierra Wireless AirLink GX 440</option>
+<option value="146">Multilayer Director Switches</option>
+<option value="147">Nexus 2000 Series Fabric Extenders</option>
+<option value="148">Nexus 3000 Series Switches</option>
+<option value="150">Nexus 3500 Platform Switches</option>
+<option value="151">Nexus 5000 Series Switches</option>
+<option value="152">Nexus 5500 Platform Switches</option>
+<option value="153">Nexus 5600 Platform Switches</option>
+<option value="154">Nexus 6000 Series Switches</option>
+<option value="155">Nexus 7000 Series Switches</option>
+<option value="156">Nexus 7700 Series Switches</option>
+<option value="157">Nexus 9000 Series Switches - Standalone, NX-OS mode</option>
+<option value="158">Nexus 9500 R-Series Line Cards and Fabric Modules</option>
+<option value="160">Nexus 9500 R-Series Line Cards</option>
+<option value="161">Nexus 9500 R-Series Fabric Modules</option>
+<option value="162">Nexus 9000 Series Switches</option>
+<option value="163">Dell EMC XtremIO</option>
+<option value="164">Dell EMC VMAX</option>
+<option value="165">Dell EMC Unity</option>
+<option value="166">Dell EMC VPLEX</option>
+<option value="167">Firepower 4100 Series Next-Generation Firewall</option>
+<option value="168">Firepower 9300 Security Appliance</option>
+<option value="170">S820A</option>
+<option value="171">MDM6600</option>
+<option value="172">MDM9206</option>
+<option value="173">MDM9310</option>
+<option value="174">MDM9607</option>
+<option value="175">MDM9615</option>
+<option value="176">MDM9625</option>
+<option value="177">MDM9635M</option>
+<option value="178">MDM9640</option>
+<option value="179">MDM9645</option>
+<option value="180">MDM9650</option>
+<option value="181">MDM9655</option>
+<option value="182">MSM8909W</option>
+<option value="183">S820AM</option>
+<option value="184">QSC6270</option>
+<option value="185">S600</option>
+<option value="186">SD 200</option>
+<option value="187">SD 210</option>
+<option value="188">SD 212</option>
+<option value="189">SD 205</option>
+<option value="190">SD 400</option>
+<option value="191">SD 410</option>
+<option value="192">SD 412</option>
+<option value="193">SD 425</option>
+<option value="194">SD 430</option>
+<option value="195">SD 615</option>
+<option value="196">SD 616</option>
+<option value="197">SD 415</option>
+<option value="198">SD 617</option>
+<option value="199">SD 625</option>
+<option value="200">SD 650</option>
+<option value="201">SD 652</option>
+<option value="202">SD 800</option>
+<option value="203">SD 808</option>
+<option value="204">Cisco 3000 Series Industrial Security Appliances (ISAs)</option>
+<option value="205">SD 820</option>
+<option value="206">SD 835</option>
+<option value="207">SDX20M</option>
+<option value="208">SD 600</option>
+<option value="209">SD 602A</option>
+<option value="210">SDX20</option>
+<option value="211">SD 810</option>
+<option value="212">SD 450</option>
+<option value="213">SD 845</option>
+<option value="214">MDM9207</option>
+<option value="215">APQ8096AU</option>
+<option value="216">MSM8996AU</option>
+<option value="217">SD 850</option>
+<option value="218">MDM0296</option>
+<option value="220">SD 820A</option>
+<option value="221">SDX 20</option>
+<option value="222">MDM9649</option>
+<option value="223">IPQ4019</option>
+<option value="224">QCA4531</option>
+<option value="225">QCA6174A</option>
+<option value="226">QCA6574AU</option>
+<option value="227">QCA6584</option>
+<option value="228">QCA6584AU</option>
+<option value="229">QCA9377</option>
+<option value="230">QCA9378</option>
+<option value="231">QCA9379</option>
+<option value="232">SD 427</option>
+<option value="233">SD 435</option>
+<option value="234">SDM630</option>
+<option value="235">SDM636</option>
+<option value="236">SDM660</option>
+<option value="237">FSM9055</option>
+<option value="238">MSM8976</option>
+<option value="239">MSM8937</option>
+<option value="240">SDM845</option>
+<option value="241">MSM8952</option>
+<option value="242">IPQ8064</option>
+<option value="243">QCA9980</option>
+<option value="244">QCA9558</option>
+<option value="245">QCA9880</option>
+<option value="246">QCA9886</option>
+<option value="247">QCA9990</option>
+<option value="248">Cisco Firepower 2100 Series Security Appliances</option>
+<option value="249">Cisco Firepower 4100 Series Security Appliances</option>
+<option value="250">Cisco FTD Virtual (FTDv)</option>
+<option value="251">MDM8996</option>
+<option value="252">MSM8996</option>
+<option value="253">MSM8998</option>
+<option value="254">Canon LBP7750C</option>
+<option value="255">Canon LBP3370</option>
+<option value="256">Canon LBP3460</option>
+<option value="257">Canon LBP6650</option>
+<option value="259">FortiGate-60E-LENC</option>
+<option value="260">Cisco Nexus 5500 Series Switches</option>
+<option value="261">Cisco Nexus 5600 Series Switches</option>
+<option value="262">Cisco Nexus 6000 Series Switches</option>
+<option value="268">vSRX Series</option>
+<option value="270">Cisco ASR 9000 Series Aggregation Services Routers</option>
+<option value="271">Cisco ASR 9922 Router</option>
+<option value="272">Cisco ASR 9010 Router</option>
+<option value="273">Cisco ASR 9904 Router</option>
+<option value="274">Cisco ASR 9006 Router</option>
+<option value="275">Cisco ASR 9001 Router</option>
+<option value="276">Cisco ASR 9912 Router</option>
+<option value="277">SDA660</option>
+<option value="278">Nexus 3000</option>
+<option value="279">Nexus 9000</option>
+<option value="280">Nexus 2000</option>
+<option value="281">Nexus 5500</option>
+<option value="282">Nexus 5600</option>
+<option value="283">Nexus 6000</option>
+<option value="284">Nexus 3600</option>
+<option value="285">Nexus 9500 R-Series</option>
+<option value="286">Nexus 3500</option>
+<option value="287">UCS 6100</option>
+<option value="288">UCS 6200</option>
+<option value="289">UCS 6300</option>
+<option value="290">CC2642R</option>
+<option value="291">CC2640R2</option>
+<option value="292">CC2640</option>
+<option value="293">CC2650</option>
+<option value="294">CC2540</option>
+<option value="295">CC2541</option>
+<option value="297">CC2640R2F</option>
+<option value="298">CC1350</option>
+<option value="300">Cisco Aironet 1810</option>
+<option value="304">Cisco Aironet 4800</option>
+<option value="311">SD 710</option>
+<option value="312">SDM439</option>
+<option value="313">SD 429</option>
+<option value="314">SD 439</option>
+<option value="315">SD 670</option>
+<option value="316">SXR1130</option>
+<option value="317">SD 636</option>
+<option value="318">SD 712</option>
+<option value="319">Snapdragon High Med 2016</option>
+<option value="320">SDX24</option>
+<option value="321">SD 632</option>
+<option value="325">Adaptive Security Appliance (ASA) 5500-X Series with FirePOWER Services</option>
+<option value="326">Adaptive Security Appliance (ASA) 5500-X Series Next-Generation Firewalls</option>
+<option value="327">Advanced Malware Protection (AMP) for Networks, 7000 Series Appliances</option>
+<option value="328">Advanced Malware Protection (AMP) for Networks, 8000 Series Appliances</option>
+<option value="329">Firepower 2100 Series Security Appliances</option>
+<option value="330">Firepower 4100 Series Security Appliances</option>
+<option value="331">FirePOWER 7000 Series Appliances</option>
+<option value="332">FirePOWER 8000 Series Appliances</option>
+<option value="333">Firepower 9300 Series Security Appliances</option>
+<option value="334">FirePOWER Threat Defense for Integrated Services Routers (ISRs)</option>
+<option value="335">Firepower Threat Defense Virtual</option>
+<option value="336">Industrial Ethernet 3000 Series Switches</option>
+<option value="337">Next-Generation Intrusion Prevention System (NGIPSv)</option>
+<option value="338">Virtual Next-Generation Intrusion Prevention System (NGIPSv)</option>
+<option value="339">Cisco 3000 Series Industrial Security Appliances (ISA)</option>
+<option value="340">ASA 5500-X Series Next-Generation Firewalls</option>
+<option value="341">ASA Services Module for Cisco Catalyst 6500 Series Switches and Cisco 7600 Series Routers</option>
+<option value="342">Adaptive Security Virtual Appliance (ASAv)</option>
+<option value="343">Firepower 9300 ASA Security Module</option>
+<option value="344">FTD Virtual (FTDv)</option>
+<option value="346">Cisco Firepower Threat Defense Virtual (FTDv)</option>
+<option value="347">МФК1500</option>
+<option value="348">МФК3000</option>
+<option value="349">Catalyst 3560X-48T-E Switch</option>
+<option value="350">Catalyst 2960C-8TC-S Switch</option>
+<option value="351">Catalyst 3560X-48P-S Switch</option>
+<option value="352">Catalyst 2960X-48LPS-L Switch</option>
+<option value="353">Catalyst 3560X-48U-S Switch</option>
+<option value="354">Catalyst 3560CG-8TC-S Compact Switch</option>
+<option value="355">Catalyst 2960X-24PS-L Switch</option>
+<option value="356">Embedded Service 2020 CON B Switch</option>
+<option value="357">Catalyst 2960X-24PD-L Switch</option>
+<option value="359">ARM926EJ</option>
+<option value="360">MGE Galaxy 3000</option>
+<option value="361">MGE Galaxy 4000</option>
+<option value="362">MGE Galaxy 5000</option>
+<option value="363">MGE Galaxy 6000</option>
+<option value="364">MGE Galaxy 9000</option>
+<option value="365">MGE EPS 6000</option>
+<option value="366">MGE EPS 7000</option>
+<option value="367">MGE EPS 8000</option>
+<option value="368">MGE Comet UPS</option>
+<option value="370">STS MGE Upsilon</option>
+<option value="371">Cisco FirePOWER Appliance 7050</option>
+<option value="372">Cisco FirePOWER Appliance 8360</option>
+<option value="373">Cisco Firepower Management Center 2500</option>
+<option value="374">Cisco FirePOWER Appliance 8120</option>
+<option value="375">Cisco FirePOWER Appliance 8260</option>
+<option value="376">Cisco AMP 8150</option>
+<option value="377">Cisco FirePOWER Appliance 8350</option>
+<option value="378">Cisco FirePOWER Appliance 8130</option>
+<option value="379">Cisco AMP 7150</option>
+<option value="380">Cisco FirePOWER Appliance 8140</option>
+<option value="381">Cisco FirePOWER Appliance 8270</option>
+<option value="382">Cisco FirePOWER Appliance 8390</option>
+<option value="383">Cisco NGIPS Virtual Appliance</option>
+<option value="384">Cisco Firepower Management Center 4500</option>
+<option value="385">Cisco FirePOWER Appliance 8250</option>
+<option value="386">Cisco FirePOWER Appliance 7010</option>
+<option value="387">Cisco FirePOWER Appliance 7120</option>
+<option value="388">Cisco FireSIGHT Management Center 750</option>
+<option value="389">Cisco FirePOWER Appliance 8370</option>
+<option value="390">Cisco Firepower Management Center 4000</option>
+<option value="391">Cisco FireSIGHT Management Center 3500</option>
+<option value="392">Cisco FirePOWER Appliance 8290</option>
+<option value="393">Cisco FirePOWER Appliance 7125</option>
+<option value="394">Cisco FireSIGHT Management Center 1500</option>
+<option value="395">Cisco Firepower Management Center 1000</option>
+<option value="396">Cisco FirePOWER Appliance 7020</option>
+<option value="397">Cisco FirePOWER Appliance 7110</option>
+<option value="399">Cisco FirePOWER Appliance 7115</option>
+<option value="400">Cisco Firepower Management Center 2000</option>
+<option value="402">Cisco FirePOWER Appliance 7030</option>
+<option value="403">EX2300</option>
+<option value="404">EX3400</option>
+<option value="405">EX4600</option>
+<option value="406">QFX3K</option>
+<option value="407">QFX5K</option>
+<option value="408">QFX5200</option>
+<option value="409">QFX5110</option>
+<option value="410">SRX</option>
+<option value="411">EX2200/VC</option>
+<option value="412">EX3300/VC</option>
+<option value="413">EX4550/VC</option>
+<option value="414">EX3200</option>
+<option value="415">EX4200</option>
+<option value="416">EX4300</option>
+<option value="417">EX6200</option>
+<option value="419">QFX3600</option>
+<option value="420">QFX3500</option>
+<option value="421">QFX5100</option>
+<option value="422">NFX150</option>
+<option value="423">NFX250</option>
+<option value="424">QFX10000 Series</option>
+<option value="425">Orange Livebox ARV7519RW22</option>
+<option value="426">TelePresence Multipoint Control Unit 5300 Series</option>
+<option value="427">TelePresence Multipoint Control Unit MSE 8510</option>
+<option value="428">TelePresence Multipoint Control Unit MSE 8420</option>
+<option value="429">TelePresence Server 7010</option>
+<option value="430">TelePresence Server MSE 8710</option>
+<option value="431">TelePresence Server on Multiparty Media 310</option>
+<option value="432">TelePresence Server on Multiparty Media 320</option>
+<option value="433">TelePresence Server on Multiparty Media 820</option>
+<option value="434">Secutech RiS-11</option>
+<option value="435">Secutech RiS-22</option>
+<option value="436">Secutech RiS-33</option>
+<option value="437">IP Conference Phone 7832</option>
+<option value="438">IP Conference Phone 8832</option>
+<option value="439">IP Phone 7811</option>
+<option value="440">IP Phone 7821</option>
+<option value="441">IP Phone 7841</option>
+<option value="442">IP Phone 7861</option>
+<option value="443">IP Phone 8800 Series</option>
+<option value="444">IP Phone 8800 Series with Multiplatform Firmware</option>
+<option value="445">IP Phone 8800 Series - VPN feature</option>
+<option value="446">IP Phone 8861</option>
+<option value="447">IP Phone 8865 with Multiplatform Firmware</option>
+<option value="448">IP Phone 8865</option>
+<option value="449">Unified IP Conference Phone 8831</option>
+<option value="450">Unified IP Conference Phone 8831 for Third-Party Call Control</option>
+<option value="451">Wireless IP Phone 8821</option>
+<option value="452">SPA112 Series IP Phones</option>
+<option value="453">SPA525 Series IP Phones</option>
+<option value="454">SPA5X5 Series IP Phones</option>
+<option value="455">Siemens SIMATIC S7-400</option>
+<option value="456">Siemens SIMATIC S7-400 PN/DP</option>
+<option value="457">Siemens SIMATIC S7-400H</option>
+<option value="458">Siemens SIMATIC S7-410</option>
+<option value="459">Network Convergence System 1000 Series</option>
+<option value="460">Intel Core</option>
+<option value="461">Intel Xeon</option>
+<option value="462">Cisco Nexus 3000 Series Fabric Switches</option>
+<option value="463">Cisco Nexus 3500 Series Fabric Switches</option>
+<option value="464">Cisco Nexus 9000 Series Fabric Switches</option>
+<option value="465">Cisco Nexus 9000</option>
+<option value="466">Cisco Firepower 4100</option>
+<option value="467">Cisco Firepower 9300</option>
+<option value="468">Cisco MDS 9000</option>
+<option value="469">Cisco Nexus 3000</option>
+<option value="470">Cisco Nexus 3500</option>
+<option value="471">Cisco Nexus 7000</option>
+<option value="472">Cisco Nexus 7700</option>
+<option value="474">Cisco UCS 6200</option>
+<option value="475">Cisco UCS 6300</option>
+<option value="476">Cisco MDS 9000 Series Multilayer Switches</option>
+<option value="477">Cisco Nexus 3000 Series Switches</option>
+<option value="478">Cisco Nexus 3500 Platform Switches</option>
+<option value="479">Cisco Nexus 3600 Platform Switches</option>
+<option value="480">Cisco Nexus 7000 Series Switches</option>
+<option value="481">Cisco Nexus 7700 Series Switches</option>
+<option value="482">Cisco Nexus 9000 Series Switches</option>
+<option value="483">Cisco Nexus 9500 R-Series Line Cards and Fabric Modules</option>
+<option value="484">Cisco Nexus 9500 R-Series Line Cards</option>
+<option value="485">Cisco Firepower 4100 Series Next-Generation Firewalls</option>
+<option value="486">Cisco Firepower 9300 Security Appliance</option>
+<option value="487">Cisco Nexus 2000 Series Fabric Extenders</option>
+<option value="488">Cisco Nexus 5500 Platform Switches</option>
+<option value="489">Cisco Nexus 5600 Platform Switches</option>
+<option value="491">Cisco Nexus 1000V</option>
+<option value="492">Cisco Nexus 3600</option>
+<option value="493">Cisco Nexus 5500</option>
+<option value="494">Cisco Nexus 5600</option>
+<option value="495">Cisco Nexus 6000</option>
+<option value="496">Cisco Nexus 9500</option>
+<option value="497">Cisco UCS 6400</option>
+<option value="499">Cisco Nexus 2000</option>
+<option value="500">DIR-823G</option>
+<option value="501">Dasan GPON</option>
+<option value="502">Cisco IP Phone 8800</option>
+<option value="503">Cisco IP Conference Phone 8832</option>
+<option value="504">Cisco IP Phone 8821</option>
+<option value="505">Cisco IP Phone 8821-EX</option>
+<option value="507">Cisco IP Phone 7800</option>
+<option value="508">Cisco IP Conference Phone 8831</option>
+<option value="509">Cisco Catalyst 6500</option>
+<option value="510">Small Business SPA514G IP Phones</option>
+<option value="511">Cisco ASR 9000</option>
+<option value="512">Cisco Aironet 1540 Series APs</option>
+<option value="513">Cisco Aironet 1560 Series APs</option>
+<option value="514">Cisco Aironet 1800 Series APs</option>
+<option value="515">Cisco Aironet 2800 Series APs</option>
+<option value="516">Cisco Aironet 3800 Series APs</option>
+<option value="517">QFX 5000 series</option>
+<option value="518">SRX5000 Series</option>
+<option value="519">SRX Series</option>
+<option value="520">NFX Series</option>
+<option value="521">ACX Series</option>
+<option value="522">QFX10K Series</option>
+<option value="523">EX series</option>
+<option value="524">QFX series</option>
+<option value="525">QFX5200 Series</option>
+<option value="526">QFX5110 Series</option>
+<option value="527">EX3400 Series</option>
+<option value="528">EX2300 Series</option>
+<option value="529">Yealink SIP-T21P E2</option>
+<option value="530">Cisco Firepower 2100 Series</option>
+<option value="531">Cisco ASA 5500 Series</option>
+<option value="532">Cisco ASA 5500-X Series</option>
+<option value="533">Cisco ASA Services Module for Cisco Catalyst 6500 Series</option>
+<option value="534">Cisco ASA Services Module for Cisco 7600 Series</option>
+<option value="535">Cisco Web Security Appliance</option>
+<option value="536">Cisco ASA 5505 Series</option>
+<option value="537">Cisco ASA 5500-X Series with FirePOWER Services</option>
+<option value="538">Cisco Advanced Malware Protection for Networks for FirePOWER 7000 Series</option>
+<option value="539">Cisco AMP for Networks for FirePOWER 8000 Series</option>
+<option value="541">Cisco Firepower 8000 Series</option>
+<option value="542">Cisco Small Business 200 Series</option>
+<option value="543">Cisco Small Business 300 Series</option>
+<option value="544">Cisco Small Business 500 Series</option>
+<option value="545">Cisco 250 Series</option>
+<option value="546">Cisco 350 Series</option>
+<option value="547">Cisco 350X Series</option>
+<option value="548">Cisco 550X Series</option>
+<option value="549">Cisco Catalyst 7600 Series</option>
+<option value="550">Intel Broadwell U i5 vPro</option>
+<option value="551">8th Generation Intel Core Processor</option>
+<option value="552">7th Generation Intel Core Processor</option>
+<option value="553">Juniper EX4300-MP Series</option>
+<option value="554">Juniper SRX340 Series</option>
+<option value="555">Juniper SRX345 Series</option>
+<option value="556">Juniper SRX Series</option>
+<option value="558">Cisco Aironet 1560</option>
+<option value="559">Cisco Aironet 1800</option>
+<option value="560">Cisco Aironet 2800</option>
+<option value="561">Cisco Aironet 3800</option>
+<option value="562">Cisco Aironet 1540</option>
+<option value="563">Cisco 3000 Series Industrial Security Appliances</option>
+<option value="564">Cisco ASR 9000v</option>
+<option value="565">Cisco ASR 9001</option>
+<option value="566">Cisco ASR 9006</option>
+<option value="567">Cisco ASR 9010</option>
+<option value="568">Cisco ASR 9901</option>
+<option value="569">Cisco ASR 9904</option>
+<option value="570">Cisco ASR 9906</option>
+<option value="571">Cisco ASR 9910</option>
+<option value="572">Cisco ASR 9912</option>
+<option value="573">Cisco ASR 9922</option>
+<option value="574">Cisco RV320</option>
+<option value="575">Cisco RV325</option>
+<option value="576">Catalyst WS-C2960L-8TS-LL</option>
+<option value="577">Catalyst WS-C2960L-8PS-LL</option>
+<option value="578">Catalyst WS-C2960L-16TS-LL</option>
+<option value="579">Catalyst WS-C2960L-16PS-LL</option>
+<option value="580">Catalyst WS-C2960L-24TS-LL</option>
+<option value="581">Catalyst WS-C2960L-24PS-LL</option>
+<option value="582">Catalyst WS-C2960L-48TS-LL</option>
+<option value="583">Catalyst WS-C2960L-48PS-LL</option>
+<option value="584">Catalyst WS-C2960L-24TQ-LL</option>
+<option value="585">Catalyst WS-C2960L-24PQ-LL</option>
+<option value="586">Catalyst WS-C2960L-48TQ-LL</option>
+<option value="587">Catalyst WS-C2960L-48PQ-LL</option>
+<option value="588">Catalyst WS-C2960L-SM-8TS</option>
+<option value="589">Catalyst WS-C2960L-SM-8PS</option>
+<option value="590">Catalyst WS-C2960L-SM-16TS</option>
+<option value="591">Catalyst WS-C2960L-SM-16PS</option>
+<option value="592">Catalyst WS-C2960L-SM-24TS</option>
+<option value="593">Catalyst WS-C2960L-SM-24PS</option>
+<option value="594">Catalyst WS-C2960L-SM-48TS</option>
+<option value="595">Catalyst WS-C2960L-SM-48PS</option>
+<option value="596">Catalyst WS-C2960L-SM-24TQ</option>
+<option value="597">Catalyst WS-C2960L-SM-24PQ</option>
+<option value="598">Catalyst WS-C2960L-SM-48TQ</option>
+<option value="599">Catalyst WS-C2960L-SM-48PQ</option>
+<option value="600">Catalyst C2960L-DNA-E-8</option>
+<option value="601">Catalyst C2960L-DNA-E-16</option>
+<option value="602">Catalyst C2960L-DNA-E-24</option>
+<option value="603">Catalyst C2960L-DNA-E-48</option>
+<option value="604">Catalyst Digital Building CDB-8U</option>
+<option value="605">Catalyst Digital Building CDB-8P</option>
+<option value="606">UCS B22 M3 Blade Server</option>
+<option value="607">UCS B200 M2 Blade Server</option>
+<option value="608">UCS B200 M3 Blade Server</option>
+<option value="609">UCS B200 M4 Blade Server</option>
+<option value="610">UCS B200 M5 Blade Server</option>
+<option value="611">UCS B230 M2 Blade Server</option>
+<option value="612">UCS B250 M2 Extended Memory Blade Server</option>
+<option value="613">UCS B260 M4 Blade Server</option>
+<option value="614">UCS B420 M3 Blade Server</option>
+<option value="615">UCS B420 M4 Blade Server</option>
+<option value="616">UCS B440 M2 High-Performance Blade Server</option>
+<option value="617">UCS B460 M4 Blade Server</option>
+<option value="618">UCS B480 M5 Blade Server</option>
+<option value="619">Cisco MDS 9000 Series</option>
+<option value="620">Cisco Nexus 1000V Switch for Microsoft Hyper-V</option>
+<option value="621">Cisco Nexus 1000V Switch for VMware vSphere</option>
+<option value="622">Cisco Nexus 3000 Series</option>
+<option value="624">Cisco Nexus 9000 Series Switches in standalone NX-OS mode</option>
+<option value="628">Cisco Nexus 9000 Series Fabric Switches in ACI mode</option>
+<option value="629">Cisco Nexus 9500 R-Series Switching Platform</option>
+<option value="630">Cisco ASR 9000 Series</option>
+<option value="631">Cisco Nexus 7000 Series</option>
+<option value="632">Cisco Nexus 7700 Series</option>
+<option value="633">Cisco MDS 9700 Series Multilayer Directors</option>
+<option value="634">Cisco Nexus 3600 Platform</option>
+<option value="635">Cisco Nexus 9000 Series</option>
+<option value="636">Cisco Nexus 9500 R-Series</option>
+<option value="637">Cisco Nexus 3500 Series</option>
+<option value="638">Cisco Nexus 3600 Series</option>
+<option value="639">Cisco Nexus 9500 Series</option>
+<option value="640">Nexus 3500 Platform</option>
+<option value="641">Nexus 3000 Series</option>
+<option value="642">Nexus 9500 R-Series Switching Platform</option>
+<option value="643">Nexus 7000 Series</option>
+<option value="644">Nexus 7700 Series</option>
+<option value="645">MDS 9000 Series Multilayer</option>
+<option value="646">Nexus 3600 Platform</option>
+<option value="647">Nexus 5500 Series</option>
+<option value="648">Nexus 5600 Series</option>
+<option value="649">Nexus 6000 Series</option>
+<option value="650">UCS 6200 Fabric Interconnects</option>
+<option value="651">UCS 6300 Fabric Interconnects</option>
+<option value="652">Firepower 4100 Series</option>
+<option value="654">Firepower 9300 Security Appliances</option>
+<option value="655">Nexus 9000 Series in Standalone NX-OS Mode</option>
+<option value="657">UCS 6200 Series Fabric Interconnects</option>
+<option value="658">UCS 6300 Series Fabric Interconnects</option>
+<option value="659">UCS 6400 Series Fabric Interconnects</option>
+<option value="660">UCS C125 M5 Rack Server Node</option>
+<option value="661">UCS C220 M4 Rack Server</option>
+<option value="662">UCS C220 M5 Rack Server</option>
+<option value="663">UCS C240 M4 Rack Server</option>
+<option value="664">UCS C240 M5 Rack Server</option>
+<option value="665">UCS C460 M4 Rack Server</option>
+<option value="666">UCS C480 M5 Rack Server</option>
+<option value="667">MDS 9000 Series</option>
+<option value="668">Nexus 1000 Virtual Edge</option>
+<option value="669">Nexus 1000V for Microsoft Hyper-V</option>
+<option value="670">UCS 6200 Series</option>
+<option value="671">UCS 6300 Series</option>
+<option value="672">UCS 6400 Series</option>
+<option value="673">Nexus 9000 Series</option>
+<option value="674">Firepower 9300 Series</option>
+<option value="675">Nexus 9500 R-Series Platform</option>
+<option value="676">Nexus 5600 Platform</option>
+<option value="677">Nexus 1000V for VMware vSphere</option>
+<option value="678">MDS 9700 Series Multilayer Directors</option>
+<option value="679">vBond Orchestrator Software</option>
+<option value="680">vEdge 100 Series Routers</option>
+<option value="681">vEdge 1000 Series Routers</option>
+<option value="682">vEdge 2000 Series Routers</option>
+<option value="683">vEdge 5000 Series Routers</option>
+<option value="684">vEdge Cloud Router Platform</option>
+<option value="685">vManage Network Management Software</option>
+<option value="686">vSmart Controller Software</option>
+<option value="687">TelePresence Integrator C Series</option>
+<option value="688">TelePresence EX Series</option>
+<option value="689">TelePresence MX Series</option>
+<option value="690">TelePresence SX Series</option>
+<option value="691">Webex Room Series</option>
+<option value="693">Virtualized Packet Core-Single Instance (VPC-SI)</option>
+<option value="694">Virtualized Packet Core-Distributed Instance (VPC-DI)</option>
+<option value="695">MDS 9000 Series Multilayer Switches</option>
+<option value="696">Nexus 5500 Platform</option>
+<option value="697">Nexus 1000V Switch for Microsoft Hyper-V</option>
+<option value="699">ASR 903 - 400G</option>
+<option value="700">ASR 907 - 400G</option>
+<option value="701">CBR-8</option>
+<option value="702">NIM-1GE-CU-SFP</option>
+<option value="703">NIM-2GE-CU-SFP</option>
+<option value="704">SM-X-PVDM-1000</option>
+<option value="705">SM-X-PVDM-2000</option>
+<option value="706">SM-X-PVDM-3000</option>
+<option value="707">SM-X-PVDM-500</option>
+<option value="708">A900-RSP2A-128</option>
+<option value="709">A900-RSP2A-64</option>
+<option value="710">A900-RSP3C-200</option>
+<option value="711">ASR-920-10SZ-PD</option>
+<option value="712">ASR-920-20SZ-M</option>
+<option value="713">ASR-920-24SZ-IM</option>
+<option value="714">C6800-16P10G-XL</option>
+<option value="715">C6800-32P10G-XL</option>
+<option value="716">C6800-8P10G-XL</option>
+<option value="717">C6800-8P40G-XL</option>
+<option value="718">C6800-SUP6T</option>
+<option value="719">C6800-SUP6T-XL</option>
+<option value="720">ASR-920-12SZ-A</option>
+<option value="721">ASR-920-12SZ-D</option>
+<option value="722">ASR-920-12CZ-A</option>
+<option value="723">ASR-920-12CZ-D</option>
+<option value="724">ASR-920-24TZ-M</option>
+<option value="725">ASR-920-24SZ-M</option>
+<option value="726">ASR-920-4SZ-A</option>
+<option value="727">ASR-920-4SZ-D</option>
+<option value="728">ASR-920-12SZ-IM-CC</option>
+<option value="729">ASR-920-12SZ-IM</option>
+<option value="730">Cisco Catalyst 9600</option>
+<option value="731">CBR-CCAP-LC-40G-R</option>
+<option value="732">Cisco 1120</option>
+<option value="733">Cisco 1240</option>
+<option value="734">Cisco 809</option>
+<option value="735">Cisco 829</option>
+<option value="736">C6816-X-LE</option>
+<option value="737">C6824-X-LE-40G</option>
+<option value="738">C6832-X-LE</option>
+<option value="739">C6840-X-LE-40G</option>
+<option value="740">A99-16X100GE-X-SE</option>
+<option value="741">A9K-16X100GE-TR</option>
+<option value="742">A9K-16X100GE-CM</option>
+<option value="743">A99-32X100GE-TR</option>
+<option value="744">A99-32X100GE-CM</option>
+<option value="745">A9K-RSP5-TR</option>
+<option value="746">A9K-RSP5-SE</option>
+<option value="747">A99-RP3-TR</option>
+<option value="748">A99-RP3-SE</option>
+<option value="749">NC55-MOD-A-S</option>
+<option value="750">NC55-24H12F-SE</option>
+<option value="751">NC55-36X100G-A-SE</option>
+<option value="752">NC55-5504-FC</option>
+<option value="753">NC55-5516-FC</option>
+<option value="754">NCS-55A2-MOD-S</option>
+<option value="755">NCS-55A2-MOD-HD-S</option>
+<option value="756">NCS-55A2-MOD-HX-S</option>
+<option value="757">NCS-55A2-MOD-SE-S</option>
+<option value="758">NC55A2-MOD-SE-H-S</option>
+<option value="759">NCS-5501-SE</option>
+<option value="760">NCS-5501</option>
+<option value="761">NCS-5502-SE</option>
+<option value="762">NCS-5502</option>
+<option value="763">NCS-55A1-24H</option>
+<option value="764">NCS-55A1-36H-S</option>
+<option value="765">NCS-55A1-36H-SE-S</option>
+<option value="766">Network Convergence System 1001</option>
+<option value="767">Network Convergence System 1002</option>
+<option value="768">Network Convergence System 5001</option>
+<option value="769">Network Convergence System 5002</option>
+<option value="770">N540-ACC-SYS</option>
+<option value="771">N540-24Z8Q2C-M</option>
+<option value="772">N540-24Z8Q2C-SYS</option>
+<option value="773">N540X-ACC-SYS</option>
+<option value="774">NC55-6X200-DWDM-S</option>
+<option value="775">NC55-36X100G-S</option>
+<option value="776">N3K-C31108PC-V</option>
+<option value="777">N3K-C31108TC-V</option>
+<option value="778">N3K-C3132C-Z</option>
+<option value="779">N3K-C3264C-E</option>
+<option value="780">N9K-C9332C</option>
+<option value="781">N9K-C9364C</option>
+<option value="782">N9K-SUP-A</option>
+<option value="783">N9K-SUP-B</option>
+<option value="784">N9K-C9236C</option>
+<option value="785">N9K-C92160YC-X</option>
+<option value="786">N9K-C92300YC</option>
+<option value="787">N9K-C92304QC</option>
+<option value="788">N9K-C9272Q</option>
+<option value="789">N9K-C93180YC-FX</option>
+<option value="790">N9K-C9348GC-FXP</option>
+<option value="791">N9K-C93108TC-FX</option>
+<option value="792">N9K-C9232C</option>
+<option value="793">N9K-C93240YC-FX2</option>
+<option value="794">N9K-C93180YC-EX</option>
+<option value="795">N9K-C93108TC-EX</option>
+<option value="796">N9K-C93180LC-EX</option>
+<option value="797">N9K-SUP-A+</option>
+<option value="798">N9K-SUP-B+</option>
+<option value="799">DS-X9334-K9</option>
+<option value="800">N7K-M348XP-25L</option>
+<option value="801">N77-M312CQ-26L</option>
+<option value="802">N7K-M324FQ-25L</option>
+<option value="803">N77-M348XP-23L</option>
+<option value="804">N77-SUP3E</option>
+<option value="805">DS-X9648-1536K9</option>
+<option value="806">Intel Dual Band Wireless-AC 7260</option>
+<option value="807">Intel Dual Band Wireless-N 7260</option>
+<option value="808">Intel Wireless-N 7260</option>
+<option value="809">Intel Dual Band Wireless-AC 7260 for Desktop</option>
+<option value="810">Intel Dual Band Wireless-AC 7265 (Rev. C)</option>
+<option value="811">Intel Dual Band Wireless-N 7265 (Rev. C)</option>
+<option value="812">Intel Wireless-N 7265 (Rev. C)</option>
+<option value="813">Intel Dual Band Wireless-AC 3165</option>
+<option value="814">Intel Dual Band Wireless-AC 7265 (Rev. D)</option>
+<option value="815">Intel Dual Band Wireless-N 7265 (Rev. D)</option>
+<option value="816">Intel Wireless-N 7265 (Rev. D)</option>
+<option value="817">Intel Dual Band Wireless-AC 3168</option>
+<option value="818">Intel Tri-Band Wireless-AC 17265</option>
+<option value="819">Intel Dual Band Wireless-AC 8260</option>
+<option value="820">Intel Tri-Band Wireless-AC 18260</option>
+<option value="821">Intel Dual Band Wireless-AC 8265</option>
+<option value="822">Intel Dual Band Wireless-AC 8265 Desktop Kit</option>
+<option value="823">Intel Tri-Band Wireless-AC 18265</option>
+<option value="824">Intel Wireless-AC 9560</option>
+<option value="825">Intel Wireless-AC 9461</option>
+<option value="826">Intel Wireless-AC 9462</option>
+<option value="827">Intel Wireless-AC 9260</option>
+<option value="828">Intel Wi-Fi 6 AX200</option>
+<option value="829">Intel Wi-Fi 6 AX201</option>
+<option value="830">Intel Dual Band Wireless-AC 3160</option>
+<option value="831">Cisco UCS C-Series</option>
+<option value="832">System Z9</option>
+<option value="833">IP Phone 8811</option>
+<option value="834">IP Phone 8841</option>
+<option value="835">IP Phone 8845</option>
+<option value="836">IP Phone 8845 with Multiplatform Firmware</option>
+<option value="837">IP Phone 8851</option>
+<option value="839">Cisco 2500 Series Connected Grid Switches</option>
+<option value="840">Cisco Connected Grid Ethernet Switch Module Interface Card</option>
+<option value="841">Cisco Industrial Ethernet 2000 Series Switches</option>
+<option value="842">Cisco Industrial Ethernet 3000 Series Switches</option>
+<option value="843">Cisco Industrial Ethernet 3010 Series Switches</option>
+<option value="844">Cisco Industrial Ethernet 4000 Series Switches</option>
+<option value="845">Cisco Industrial Ethernet 4010 Series Switches</option>
+<option value="846">Cisco Industrial Ethernet 5000 Series Switches</option>
+<option value="847">Cisco ASA 5506-X</option>
+<option value="848">Cisco ASA 5506-X with FirePOWER Services</option>
+<option value="849">Cisco ASA 5506H-X</option>
+<option value="850">Cisco ASA 5506H-X with FirePOWER Services</option>
+<option value="851">Cisco ASA 5506W-X</option>
+<option value="852">Cisco ASA 5506W-X with FirePOWER Services</option>
+<option value="853">Cisco ASA 5508-X</option>
+<option value="854">Cisco ASA 5508-X with FirePOWER Services</option>
+<option value="855">Cisco ASA 5516-X</option>
+<option value="856">Cisco ASA 5516-X with FirePOWER Services</option>
+<option value="857">S4500 Series</option>
+<option value="858">S4600 Series</option>
+<option value="859">NVIDIA Jetson TX2</option>
+<option value="861">Cisco UCS S-Series in standalone mode</option>
+<option value="862">Cisco 5000 Series ENCS Platforms</option>
+<option value="863">Cisco UCS E-Series</option>
+<option value="864">Catalyst 3650 Series</option>
+<option value="865">Catalyst 3850 Series</option>
+<option value="866">Catalyst 4500E Supervisor Engine 8-E</option>
+<option value="867">Cisco 5760 Wireless LAN Controllers</option>
+<option value="868">Remote PHY 120</option>
+<option value="869">Remote PHY 220</option>
+<option value="870">Remote PHY Shelf 7200</option>
+<option value="871">Cisco AsyncOS</option>
+<option value="872">Telepresence Codec C40</option>
+<option value="873">vEdge Cloud</option>
+<option value="874">AMP 7150</option>
+<option value="875">AMP 8150</option>
+<option value="876">Cisco 4221 Integrated Services Router</option>
+<option value="877">Cisco 4331 Integrated Services Router</option>
+<option value="878">Cisco 4321 Integrated Services Router</option>
+<option value="879">Cisco 4431 Integrated Services Router</option>
+<option value="880">Cisco 4451-X Integrated Services Router</option>
+<option value="881">Cisco 4351 Integrated Services Router</option>
+<option value="882">Cisco Cloud Services Router 1000V</option>
+<option value="883">Cisco ISR 4000 Series</option>
+<option value="884">Cisco ASR 9000v Series</option>
+<option value="885">Cisco ASR 9001 Series</option>
+<option value="886">Cisco ASR 9006 Series</option>
+<option value="887">Cisco ASR 9010 Series</option>
+<option value="888">Cisco ASR 9901 Series</option>
+<option value="889">Cisco ASR 9904 Series</option>
+<option value="890">Cisco ASR 9906 Series</option>
+<option value="892">Cisco ASR 9912 Series</option>
+<option value="893">Cisco ASR 9922 Series</option>
+<option value="894">Cisco 510 WPAN Industrial Router</option>
+<option value="895">Cisco CGR 1000 Compute Module</option>
+<option value="896">Cisco Industrial Ethernet 4000 Series</option>
+<option value="897">Cisco IC3000 Industrial Compute Gateway</option>
+<option value="898">Cisco Unified Border Element (CUBE)</option>
+<option value="899">Cisco Unified Communications Manager Express (CME)</option>
+<option value="900">Cisco IOS Gateways with Session Initiation Protocol (SIP)</option>
+<option value="901">Cisco TDM Gateways</option>
+<option value="902">Cisco Unified Survivable Remote Site Telephony (SRST)</option>
+<option value="903">Cisco Business Edition 4000 (BE4K)</option>
+<option value="904">Cisco Catalyst 4500 Supervisor Engine 6-E</option>
+<option value="905">Cisco Catalyst 4500 Supervisor Engine 6L-E</option>
+<option value="906">Cisco Catalyst 4900M</option>
+<option value="907">Cisco Catalyst 4948E Ethernet</option>
+<option value="908">Cisco Catalyst 4948E-F Ethernet</option>
+<option value="909">Cisco 1100 Integrated Services Routers</option>
+<option value="910">Cisco 4200 Integrated Services Routers</option>
+<option value="911">Cisco 4300 Integrated Services Routers</option>
+<option value="912">Cisco Cloud Services Router (CSR) 1000V Series</option>
+<option value="913">Cisco Enterprise Network Compute System</option>
+<option value="914">Cisco Integrated Services Virtual Router</option>
+<option value="916">Cisco Firepower 1000 Series</option>
+<option value="917">Cisco Firepower 9300 Series</option>
+<option value="919">Firepower 2100 Series</option>
+<option value="920">Firepower Threat Defense Virtual (FTDv)</option>
+<option value="921">MX2008</option>
+<option value="922">MX2010</option>
+<option value="923">MX2020</option>
+<option value="924">MX480</option>
+<option value="925">MX960</option>
+<option value="926">Juniper NFX Series</option>
+<option value="927">Juniper MX Series</option>
+<option value="928">Juniper SRX 5000 Series</option>
+<option value="929">SPA112 2-Port Phone Adapter</option>
+<option value="930">SPA122 ATA with Router devices</option>
+<option value="932">Catalyst 9100</option>
+<option value="937">Cisco Small Business 250 Series</option>
+<option value="938">Cisco Small Business 350 Series</option>
+<option value="939">Cisco Small Business 350X Series</option>
+<option value="940">Cisco Small Business 550X Series</option>
+<option value="945">Cisco Aironet 1830</option>
+<option value="946">Cisco Aironet 1850</option>
+<option value="947">EX2300-C</option>
+<option value="948">SRX1500</option>
+<option value="949">Cisco 12000 Series</option>
+<option value="950">Cisco Carrier Routing System</option>
+<option value="951">Cisco Network Convergence System 4000 Series</option>
+<option value="952">Cisco Network Convergence System 6000 Series</option>
+<option value="953">Cisco 4400 Series Integrated Services Routers</option>
+<option value="954">Cisco ASR 900 Series</option>
+<option value="955">Cisco Email Security Appliance</option>
+<option value="956">SRX4000</option>
+<option value="957">vSRX Junos</option>
+<option value="958">ViPNet Coordinator HW</option>
+<option value="959">ViPNet Coordinator KB</option>
+<option value="961">Терминал микропроцессорный серии ЭКРА 200</option>
+<option value="962">USG6330</option>
+<option value="963">USG9500</option>
+<option value="966">ASR 9000 Series Aggregation Services Routers</option>
+<option value="967">IOS XRv 9000 Router</option>
+<option value="968">Network Convergence System (NCS) 540 Series Routers</option>
+<option value="969">Network Convergence System (NCS) 560 Series Routers</option>
+<option value="970">Network Convergence System (NCS) 1000 Series Routers</option>
+<option value="971">Network Convergence System (NCS) 5000 Series Routers</option>
+<option value="972">Network Convergence System (NCS) 5500 Series Routers</option>
+<option value="973">Network Convergence System (NCS) 6000 Series Routers</option>
+<option value="974">Nexus 1000 Virtual Edge for VMware vSphere</option>
+<option value="975">NC-302</option>
+<option value="976">NC-210</option>
+<option value="977">NC-220</option>
+<option value="978">NC-110</option>
+<option value="979">NC-201M</option>
+<option value="980">NC-202</option>
+<option value="981">NC-301</option>
+<option value="982">NC-310</option>
+<option value="983">NC-400</option>
+<option value="984">NC-230</option>
+<option value="985">cMT-SVR-100\200</option>
+<option value="986">XP-8741-Atom</option>
+<option value="987">HoloLens</option>
+<option value="989">Cisco 4300 Series</option>
+<option value="990">Catalyst 9800-L</option>
+<option value="991">Catalyst 9800 Series</option>
+<option value="992">800 Series Industrial Integrated Services Routers (Industrial ISRs)</option>
+<option value="993">800 Series Integrated Services Routers (ISRs)</option>
+<option value="994">1000 Series Connected Grid Routers (CGR1000) Compute Module</option>
+<option value="995">1000 Series ISRs</option>
+<option value="996">4000 Series ISRs</option>
+<option value="997">Catalyst 9x00 Series Switches</option>
+<option value="998">Catalyst IE3400 Rugged Series Switches</option>
+<option value="999">Embedded Services 3300 Series Switches</option>
+<option value="1000">IR510 WPAN Industrial Routers</option>
+<option value="1001">Catalyst 2960-L Series Switches</option>
+<option value="1002">Catalyst CDB-8P Switches</option>
+<option value="1003">Cisco ASR 920 Series Aggregation Services Router model ASR920-12SZ-IM</option>
+<option value="1004">PA-7080</option>
+<option value="1005">PA-7050</option>
+<option value="1006">MacOS</option>
+<option value="1007">vManage Software</option>
+<option value="1008">vEdge Routers</option>
+<option value="1009">ENCS 5400-W</option>
+<option value="1011">CSP 5000-W</option>
+<option value="1012">Nexus 1100 Series</option>
+<option value="1013">8000 Series Routers</option>
+<option value="1015">IOS XR, SW only</option>
+<option value="1016">Network Convergence System 540 Routers</option>
+<option value="1017">Network Convergence System 5500 Series</option>
+<option value="1018">ESA software</option>
+<option value="1019">SMA software</option>
+<option value="1020">WSA software</option>
+<option value="1021">RV340W Dual WAN Gigabit Wireless-AC VPN Router</option>
+<option value="1022">RV340 Dual WAN Gigabit VPN Router</option>
+<option value="1023">RV345 Dual WAN Gigabit VPN Router</option>
+<option value="1024">RV345P Dual WAN Gigabit POE VPN Router</option>
+<option value="1025">High-End SRX Series</option>
+<option value="1027">EX9200 Series</option>
+<option value="1028">PTX Series</option>
+<option value="1029">PTX1000 Series</option>
+<option value="1030">PTX10000 Series</option>
+<option value="1031">vMX</option>
+<option value="1032">MX150</option>
+<option value="1033">MPC10E</option>
+<option value="1034">MPC11E</option>
+<option value="1035">PTX10001</option>
+<option value="1036">PTX10003</option>
+<option value="1037">ASR 920 Series</option>
+<option value="1038">ASR 1000 Series</option>
+<option value="1039">Catalyst 9000 Series</option>
+<option value="1040">Catalyst 9200 Series</option>
+<option value="1042">SRX4100</option>
+<option value="1043">SRX4200</option>
+<option value="1044">Catalyst 9300</option>
+<option value="1045">Catalyst 9400</option>
+<option value="1046">Catalyst 9500</option>
+<option value="1047">Catalyst 9100 AP</option>
+<option value="1048">Cisco Aironet 1810 Series APs</option>
+<option value="1049">Cisco Aironet 1815 Series APs</option>
+<option value="1050">Cisco Aironet 1840 Series APs</option>
+<option value="1051">Cisco Aironet 1850 Series APs</option>
+<option value="1052">Business 100 Series APs</option>
+<option value="1053">Business 200 Series APs</option>
+<option value="1054">Catalyst IW 6300 APs</option>
+<option value="1055">ESW6300 Series APs</option>
+<option value="1056">Integrated Access Point on 1100 Integrated Services Routers</option>
+<option value="1057">Cisco 4461</option>
+<option value="1058">Cisco Firepower 4110 Series</option>
+<option value="1059">Windows</option>
+<option value="1061">CentOS 7</option>
+<option value="1062">My Cloud Mirror Gen2</option>
+<option value="1063">My Cloud EX2 Ultra</option>
+<option value="1064">My Cloud EX4100</option>
+<option value="1065">My Cloud PR2100</option>
+<option value="1066">My Cloud PR4100</option>
+<option value="1067">INOI R7</option>
+<option value="1068">Aquarius CMP NS220</option>
+<option value="1069">Byterg MVK-2020</option>
+<option value="1070">Cloud Services Router 1000V</option>
+<option value="1071">Meraki MX64</option>
+<option value="1072">Meraki MX64W</option>
+<option value="1073">Meraki MX67</option>
+<option value="1074">Meraki MX67C</option>
+<option value="1075">Meraki MX67W</option>
+<option value="1076">Meraki MX68</option>
+<option value="1077">Meraki MX68CW</option>
+<option value="1078">Meraki MX68W</option>
+<option value="1079">Meraki MX100</option>
+<option value="1080">Meraki MX84</option>
+<option value="1081">Meraki MX250</option>
+<option value="1082">Meraki MX450</option>
+<option value="1083">vEdge Cloud Routers</option>
+<option value="1084">ASR 5000 Series Aggregation Services Routers</option>
+<option value="1085">86-bit</option>
+<option value="1086">NCS1K</option>
+<option value="1087">RSPE</option>
+<option value="1088">RSP</option>
+<option value="1089">OS2</option>
+<option value="1090">OpenBAT</option>
+<option value="1091">BAT450-F</option>
+<option value="1092">NFX350</option>
+<option value="1093">QFX5210</option>
+<option value="1094">QFX5120</option>
+<option value="1095">EX4650</option>
+<option value="1096">Catalyst 8000V Edge</option>
+<option value="1098">Catalyst 8200 Series Edge</option>
+<option value="1099">Catalyst 8300 Series Edge</option>
+<option value="1100">Cloud Services Router 1000V Series</option>
+<option value="1102">5400 Enterprise Network Compute System with ISRv</option>
+<option value="1103">Catalyst 9300L Series</option>
+<option value="1104">Cisco ESR6300 Embedded Series</option>
+<option value="1105">Cisco Catalyst 4500 Series</option>
+<option value="1106">Cisco Catalyst 4500-X Series</option>
+<option value="1107">Catalyst IE3200 Rugged Series Switches</option>
+<option value="1108">Catalyst IE3300 Rugged Series Switches</option>
+<option value="1109">Catalyst IE3400 Heavy Duty Series Switches</option>
+<option value="1111">DVPSimulator EH2</option>
+<option value="1112">DVPSimulator EH3</option>
+<option value="1113">DVPSimulator ES2</option>
+<option value="1114">DVPSimulator SE</option>
+<option value="1115">DVPSimulator SS2</option>
+<option value="1116">AHSIM_5x0</option>
+<option value="1117">AHSIM_5x1</option>
+<option value="1119">Catalyst 8500L Series</option>
+<option value="1120">SRX4600</option>
+<option value="1121">SRX5000</option>
+<option value="1122">iOS</option>
+<option value="1123">UNIX</option>
+<option value="1124">EX8200/VC (XRE)</option>
+<option value="1125">QFabric Series</option>
+<option value="1126">PTX10008</option>
+<option value="1127">QFX5220</option>
+<option value="1128">MX Series</option>
+<option value="1129">PTX1000</option>
+<option value="1130">QFX Switching</option>
+<option value="1131">QFabric System</option>
+<option value="1132">SRX100</option>
+<option value="1133">SRX210</option>
+<option value="1134">SRX220</option>
+<option value="1135">SRX240m</option>
+<option value="1136">SRX300</option>
+<option value="1137">SRX320</option>
+<option value="1138">SRX340</option>
+<option value="1139">SRX345</option>
+<option value="1140">SRX550m</option>
+<option value="1141">SRX650</option>
+<option value="1143">ACX5800</option>
+<option value="1144">MX10000 Series</option>
+<option value="1145">MX240</option>
+<option value="1146">QFX5000</option>
+<option value="1148">ATM Dispenser Controller</option>
+<option value="1149">CPU: STM STR710FZ2T6</option>
+<option value="1150">Catalyst 9800-CL Wireless Controllers for Cloud</option>
+<option value="1151">Embedded Wireless Controller on Catalyst Access Points</option>
+<option value="1153">Catalyst 9800 Wireless Controllers</option>
+<option value="1154">Catalyst 8000 Series Edge Platforms</option>
+<option value="1155">Cisco ASR 920 Series Aggregation Services Routers</option>
+<option value="1156">Fedora 34</option>
+<option value="1157">Fedora 35</option>
+<option value="1158">Chrome OS</option>
+<option value="1159">Windows 10</option>
+<option value="1160">Windows 8.1</option>
+<option value="1161">AX</option>
+<option value="1162">asr_901-6cz-ft-d</option>
+<option value="1163">asr_901-6cz-ft-a</option>
+<option value="1164">asr_901-6cz-fs-d</option>
+<option value="1165">asr_901-6cz-fs-a</option>
+<option value="1166">asr_901-6cz-f-d</option>
+<option value="1167">asr_901-6cz-f-a</option>
+<option value="1168">Router 7600</option>
+<option value="1169">asr_901-4c-ft-d</option>
+<option value="1170">asr_901-4c-f-d</option>
+<option value="1171">asr_901-12c-ft-d</option>
+<option value="1172">asr_901-12c-f-d</option>
+<option value="1173">Catalyst 9105</option>
+<option value="1174">Catalyst 9115</option>
+<option value="1175">Catalyst 9117</option>
+<option value="1176">Catalyst 9120</option>
+<option value="1177">Catalyst 9124</option>
+<option value="1178">Catalyst 9130</option>
+<option value="1179">Catalyst 9800-40</option>
+<option value="1180">Catalyst 9800-40 Wireless controller</option>
+<option value="1181">Catalyst 9800-80</option>
+<option value="1182">Catalyst 9800-80 Wireless controller</option>
+<option value="1183">Catalyst 9800-CL</option>
+<option value="1184">Catalyst 9800-L-C</option>
+<option value="1185">Catalyst 9800-L-F</option>
+<option value="1186">ASR 1000</option>
+<option value="1187">ASR 1000 ESP100</option>
+<option value="1189">Cisco ASR 9902</option>
+<option value="1190">Cisco ASR 9903</option>
+<option value="1191">ASR 1000 X</option>
+<option value="1192">ASR 1000 Series RP2</option>
+<option value="1193">ASR 1000 Series RP3</option>
+<option value="1194">ASR 1001</option>
+<option value="1195">ASR 1001-HX</option>
+<option value="1196">ASR 1001-HX-R</option>
+<option value="1197">ASR 1001-X</option>
+<option value="1198">ASR 1001-X R</option>
+<option value="1199">ASR 1002</option>
+<option value="1200">ASR 1002-HX</option>
+<option value="1201">ASR 1002-HX R</option>
+<option value="1202">ASR 1002-X</option>
+<option value="1204">ASR 1002-X R</option>
+<option value="1205">ASR 1004</option>
+<option value="1206">ASR 1006-X</option>
+<option value="1207">ASR 1006</option>
+<option value="1208">ASR 1009-X</option>
+<option value="1209">ASR 1013</option>
+<option value="1210">ASR 1023</option>
+<option value="1211">1100 Series ISRs</option>
+<option value="1212">1100-4G Series ISRs (6G)</option>
+<option value="1213">1100-4P Series ISRs</option>
+<option value="1216">1101 Series ISRs</option>
+<option value="1217">1101-4P Series ISP</option>
+<option value="1218">1109 Series ISRs</option>
+<option value="1219">1109-2P Series ISRs</option>
+<option value="1220">1109-4P Series ISRs</option>
+<option value="1221">1111X Series ISRs</option>
+<option value="1222">1111X-8P Series ISRs</option>
+<option value="1223">111X Series ISRs</option>
+<option value="1224">1120 Series ISRs</option>
+<option value="1225">1160 Series ISRs</option>
+<option value="1226">422 Series ISRs</option>
+<option value="1227">4221 Series ISRs</option>
+<option value="1228">4321 Series ISRs</option>
+<option value="1229">4331 Series ISRs</option>
+<option value="1230">4351 Series ISRs</option>
+<option value="1231">4431 Series ISRs</option>
+<option value="1232">4451 Series ISRs</option>
+<option value="1233">4461 Series ISRs</option>
+<option value="1243">ACX710 Series</option>
+<option value="1244">x86 Intel</option>
+<option value="1245">ACX1000</option>
+<option value="1246">ACX1100</option>
+<option value="1247">ACX2100</option>
+<option value="1248">ACX2200</option>
+<option value="1249">ACX4000</option>
+<option value="1250">ACX500</option>
+<option value="1251">ACX5048</option>
+<option value="1252">ACX5096</option>
+<option value="1254">F+ Life Tab Plus</option>
+<option value="1255">Juniper ACX5448</option>
+<option value="1256">Juniper MX-SPC3</option>
+<option value="1258">Cisco Nexus 9200 Platform Switches</option>
+<option value="1259">Cisco Nexus 9300 Platform Switches</option>
+<option value="1303">3504 Wireless Controller</option>
+<option value="1304">5520 Wireless Controller</option>
+<option value="1305">8540 Wireless Controller</option>
+<option value="1306">Catalyst 8500 Series</option>
+<option value="1307">Citrix Hypervisor</option>
+<option value="1308">Red Hat Enterprise Linux with KVM</option>
+<option value="1309">Cisco Catalyst Micro Switches</option>
+<option value="1310">Catalyst Digital Building Series Switches</option>
+<option value="1311">5500NAC</option>
+<option value="1312">5500SHAC</option>
+<option value="1313">5500NAC2</option>
+<option value="1314">5500AC2</option>
+<option value="1315">D0-06 series CPU</option>
+<option value="1316">Cisco Catalyst 6800 Series</option>
+<option value="1317">Integrated Services Routers Generation 2 (ISR G2)</option>
+<option value="1318">x86-64-bit</option>
+<option value="1321">PTX 500Series</option>
+<option value="1322">PTX 500 Series</option>
+<option value="1323">Redmi Note 11</option>
+<option value="1324">Redmi Note 9T</option>
+<option value="1325">SuperMassive 92xx/94xx/96xx (GEN6+)</option>
+<option value="1326">SOHO W</option>
+<option value="1327">SuperMassive 10000 Series</option>
+<option value="1328">NSv (Virtual: VMWare/Hyper-V/AWS/Azure/KVM)</option>
+<option value="1329">NSv (Virtual: GEN7)</option>
+<option value="1330">NSsp (GEN7)</option>
+<option value="1331">Mashtab TrustPhone T1</option>
+<option value="1332">Industrial Ethernet Switches</option>
+<option value="1333">Micro Switches</option>
+<option value="1334">IOS XE Switches</option>
+<option value="1335">TZ</option>
+<option value="1336">NSa</option>
+<option value="1337">NSsp 12K</option>
+<option value="1338">SuperMassive 9800</option>
+<option value="1339">SuperMassive 10k</option>
+<option value="1340">VMware vCenter</option>
+<option value="1341">cSRX Series</option>
+<option value="1342">Catalyst 3600 Series Switches</option>
+<option value="1343">Catalyst 3800 Series Switches</option>
+<option value="1344">Catalyst 9200 Series Switches</option>
+<option value="1345">Catalyst 9300 Series Switches</option>
+<option value="1346">Catalyst 9400 Series Switches</option>
+<option value="1347">Catalyst 9500 Series Switches</option>
+<option value="1348">Catalyst 9600 Series Switches</option>
+<option value="1349">Catalyst 9800 Series Wireless Controllers</option>
+<option value="1350">Catalyst 9800 Embedded Wireless Controller for Catalyst 9300, 9400, and 9500 Series Switches</option>
+<option value="1351">Intel Wi-Fi 6 AX210</option>
+<option value="1352">Intel Wi-Fi 6E AX211</option>
+<option value="1353">PTX10004</option>
+<option value="1354">PTX10016</option>
+<option value="1355">Intel 8254x</option>
+<option value="1356">Intel 8255x</option>
+<option value="1357">TZ270</option>
+<option value="1358">TZ270W</option>
+<option value="1359">TZ370</option>
+<option value="1360">TZ370W</option>
+<option value="1361">TZ470</option>
+<option value="1362">TZ470W</option>
+<option value="1363">TZ570</option>
+<option value="1364">TZ570W</option>
+<option value="1365">TZ570P</option>
+<option value="1366">TZ670</option>
+<option value="1367">NSa 2700</option>
+<option value="1368">NSa 3700</option>
+<option value="1369">NSa 4700</option>
+<option value="1370">NSa 5700</option>
+<option value="1371">NSa 6700</option>
+<option value="1372">NSsp 10700</option>
+<option value="1373">NSsp 11700</option>
+<option value="1374">NSsp 13700</option>
+<option value="1375">NSv 270</option>
+<option value="1376">NSv 470</option>
+<option value="1377">NSv 870</option>
+<option value="1378">NSsp 15700</option>
+<option value="1379">NSv 10</option>
+<option value="1380">NSv 25</option>
+<option value="1381">NSv 50</option>
+<option value="1382">NSv 100</option>
+<option value="1383">NSv 200</option>
+<option value="1384">NSv 300</option>
+<option value="1385">NSv 400</option>
+<option value="1386">NSv 800</option>
+<option value="1387">NSv 1600</option>
+<option value="1388">EX46xx Series</option>
+<option value="1389">Catalyst Access Points (COS-APs)</option>
+<option value="1390">IOS XE-based devices configured with IOx</option>
+<option value="1391">QTS от 4.3.4 до 4.4.0</option>
+<option value="1392">QTS от 4.3.0 до 4.3.3</option>
+<option value="1393">QTS 4.4.1</option>
+<option value="1394">QTS 4.2.6</option>
+<option value="1395">QNAP NAS</option>
+<option value="1396">IBR600</option>
+<option value="1397">UCS 6500 Series Fabric Interconnects</option>
+<option value="1398">Cisco ASR 9900</option>
+<option value="1399">SiPass integrated AC5102 (ACC-G2)</option>
+<option value="1400">SiPass integrated ACC-AP</option>
+<option value="1406">Cisco Nexus 1000V for VMware Switch</option>
+<option value="1408">SierraWireless gx450</option>
+<option value="1409">SierraWireless lx40</option>
+<option value="1410">SierraWireless lx60</option>
+<option value="1411">SierraWireless mp70</option>
+<option value="1412">SierraWireless rv50</option>
+<option value="1413">SierraWireless rv50x</option>
+<option value="1414">SierraWireless rv55</option>
+<option value="1415">Aruba AP-305/7008</option>
+<option value="1416">DIR-853</option>
+<option value="1417">Asus RT-N10</option>
+<option value="1418">1000 Series Integrated Services Routers</option>
+<option value="1419">Cloud Services Router (CSR) 1000V Series</option>
+<option value="1420">QVR Pro</option>
+<option value="1421">QVR</option>
+<option value="1422">Pixel</option>
+<option value="1423">Red Hat Enterprise Linux</option>
+<option value="1424">Catalyst IW6300 Heavy Duty Series APs</option>
+<option value="1425">Catalyst IW9165 Heavy Duty Series</option>
+<option value="1426">Catalyst IW9165 Rugged Series</option>
+<option value="1427">Catalyst IW9167 Heavy Duty Series</option>
+<option value="1428">exynos</option>
+<option value="1430">JRR200</option>
+<option value="1431">RPL</option>
+<option value="1432">ADL-N</option>
+<option value="1433">ADL</option>
+<option value="1434">RKL</option>
+<option value="1435">TGL</option>
+<option value="1436">JSL</option>
+<option value="1437">Greenlow-R Server</option>
+<option value="1438">Greenlow-R Workstation</option>
+<option value="1439">Kaby Lake RVP</option>
+<option value="1440">Mehlow/Mehlow-R(CFL-S)</option>
+<option value="1441">Tatlow (RKS)</option>
+<option value="1442">WhiskeyLake</option>
+<option value="1443">CometLake-S</option>
+<option value="1444">TigerLake UP3/H</option>
+<option value="1445">AlderLake</option>
+<option value="1446">Alder Lake N</option>
+<option value="1448">Nexus 5500 Series Switches</option>
+<option value="1449">Nexus 5600 Series Switches</option>
+<option value="1450">Nexus 1000V Series Switches</option>
+<option value="1451">Nexus 1100 Series Cloud Services Platforms</option>
+<option value="1452">Nexus 2000 Series Switches</option>
+<option value="1453">Nexus 4000 Series Switches</option>
+<option value="1454">UCS 6100 Fabric Interconnects</option>
+<option value="1455">e510</option>
+<option value="1456">h320</option>
+<option value="1457">h350</option>
+<option value="1459">h510</option>
+<option value="1460">h550</option>
+<option value="1461">m510</option>
+<option value="1462">r310</option>
+<option value="1463">r320</option>
+<option value="1464">r350</option>
+<option value="1465">r510</option>
+<option value="1466">r550</option>
+<option value="1467">r610</option>
+<option value="1468">r650</option>
+<option value="1469">r710</option>
+<option value="1470">r720</option>
+<option value="1471">r730</option>
+<option value="1472">r750</option>
+<option value="1473">r760</option>
+<option value="1474">r850</option>
+<option value="1475">sz-144</option>
+<option value="1476">sz100</option>
+<option value="1477">sz300</option>
+<option value="1478">t310c</option>
+<option value="1479">t310d</option>
+<option value="1480">t310n</option>
+<option value="1481">t310s</option>
+<option value="1482">t350c</option>
+<option value="1483">t350d</option>
+<option value="1484">t350se</option>
+<option value="1485">t610</option>
+<option value="1486">t710</option>
+<option value="1487">t710s</option>
+<option value="1488">t750</option>
+<option value="1489">t750se</option>
+<option value="1490">t811-cm</option>
+<option value="1491">h500</option>
+<option value="1492">r300</option>
+<option value="1493">r700</option>
+<option value="1494">r560</option>
+<option value="1495">m510-jp</option>
+<option value="1496">p300</option>
+<option value="1497">q410</option>
+<option value="1498">q710</option>
+<option value="1499">q910</option>
+<option value="1500">t811-cm(non-spf)</option>
+<option value="1501">zd1000</option>
+<option value="1502">zd1100</option>
+<option value="1503">zd1200</option>
+<option value="1504">zd3000</option>
+<option value="1505">zd5000</option>
+<option value="1506">sz-144-federal</option>
+<option value="1507">sz300-federal</option>
+<option value="1508">ACX2K</option>
+<option value="1509">Chrome OS Flex</option>
+<option value="1511">HMISTU</option>
+<option value="1512">HMIGTO</option>
+<option value="1513">HMIGTU</option>
+<option value="1514">HMIGTUX</option>
+<option value="1515">HMIGK</option>
+<option value="1516">HMIET</option>
+<option value="1517">HMIGXU</option>
+<option value="1518">Beckhoff CX</option>
+<option value="1519">Nexus 9000 Series Switches in ACI mode</option>
+<option value="1520">UCS 6100 Series Fabric Interconnects</option>
+<option value="1521">ACX7100-32C</option>
+<option value="1522">ACX7100-48L</option>
+<option value="1523">ACX7509</option>
+<option value="1524">EX4300-MP</option>
+<option value="1525">Mediatek MT8167</option>
+<option value="1526">Mediatek MT8175</option>
+<option value="1527">Mediatek MT8183</option>
+<option value="1528">SRX5000-SPC3</option>
+<option value="1529">Secure Web Appliance</option>
+<option value="1530">Secure Email and Web Manager</option>
+<option value="1531">Secure Email Gateway</option>
+<option value="1532">Cisco Nexus 9332C</option>
+<option value="1533">Cisco Nexus 9364C</option>
+<option value="1534">Virtual Appliance</option>
+<option value="1535">Extreme Networks AP302W</option>
+<option value="1536">Extreme Networks AP305C/CX</option>
+<option value="1537">Extreme Networks AP305C-1</option>
+<option value="1538">Extreme Networks AP410C</option>
+<option value="1539">Extreme Networks AP410C-1</option>
+<option value="1540">Extreme Networks AP460C</option>
+<option value="1541">Extreme Networks AP460S6C</option>
+<option value="1542">Extreme Networks AP460S12C</option>
+<option value="1543">Extreme Networks AP510C/CX</option>
+<option value="1544">Extreme Networks AP630</option>
+<option value="1545">Extreme Networks AP650</option>
+<option value="1546">Extreme Networks AP650X</option>
+<option value="1547">Extreme Networks AP3000</option>
+<option value="1548">Extreme Networks AP3000X</option>
+<option value="1549">Extreme Networks AP4000</option>
+<option value="1550">Extreme Networks AP4000-1</option>
+<option value="1551">Extreme Networks AP5010</option>
+<option value="1552">Extreme Networks AP5050D</option>
+<option value="1553">Extreme Networks AP5050U</option>
+<option value="1554">Adtran SR400ac</option>
+<option value="1555">ASA 5506-X</option>
+<option value="1556">ASA 5506H-X</option>
+<option value="1557">ASA 5506W-X</option>
+<option value="1558">ASA 5508-X</option>
+<option value="1559">ASA 5512-X</option>
+<option value="1560">ASA 5515-X</option>
+<option value="1561">ASA 5516-X</option>
+<option value="1562">ASA 5525-X</option>
+<option value="1563">ASA 5545-X</option>
+<option value="1564">ASA 5585-X</option>
+<option value="1565">ASA 5500 Series Adaptive Security Appliances</option>
+<option value="1566">ASA 1000V Cloud Firewall</option>
+<option value="1567">Firepower 4110 Security Appliance</option>
+<option value="1568">Firepower 4120 Security Appliance</option>
+<option value="1569">Firepower 4140 Security Appliance</option>
+<option value="1570">Firepower 4150 Security Appliance</option>
+<option value="1571">Firepower 2100 Series Security Appliance</option>
+<option value="1572">NB800</option>
+<option value="1573">NG800</option>
+<option value="1574">NB1601</option>
+<option value="1575">NB1800</option>
+<option value="1576">NB1810</option>
+<option value="1577">NB2800</option>
+<option value="1578">NB2810</option>
+<option value="1579">NB3701</option>
+<option value="1580">NB3800</option>
+<option value="1582">Linux kernel</option>
+<option value="1583">Aruba 9200 Series Controllers</option>
+<option value="1584">Aruba 9000 Series Controllers</option>
+<option value="1585">Secure Firewall 3100 Series</option>
+<option value="1586">Network Convergence System 5700 Series</option>
+<option value="1587">Network Convergence Series (NCS) 5700 Series</option>
+<option value="1588">Cisco IOS XR White box (IOSXRWBD)</option>
+<option value="1589">Catalyst IR8300 Rugged Series Routers</option>
+<option value="1590">Catalyst 9800 Embedded Wireless Controller</option>
+<option value="1591">Embedded Wireless Controller on Catalyst 9100X Series Access Points</option>
+<option value="1592">Integrated Services Virtual Routers</option>
+<option value="1593">VG400 Analog Voice Gateways</option>
+<option value="1594">VG420 Analog Voice Gateways</option>
+<option value="1595">VG450 Analog Voice Gateways</option>
+<option value="1596">Catalyst IE3x00 Rugged Series Switches</option>
+<option value="1597">Catalyst IR1100 Rugged Series Routers</option>
+<option value="1598">Catalyst IR1800 Rugged Series Routers</option>
+<option value="1599">Catalyst IR8100 Heavy Duty Series Routers</option>
+<option value="1600">PTX10002</option>
+<option value="1601">FPC LC110x</option>
+<option value="1602">PTX3000</option>
+<option value="1603">PTX5000</option>
+<option value="1604">QFX10000</option>
+<option value="1605">A10 Thunder ADC</option>
+<option value="1606">QFX5000 Series</option>
+<option value="1607">EX4600 Series</option>
+<option value="1608">EX4100</option>
+<option value="1609">EX4400</option>
+<option value="1611">TZ 300</option>
+<option value="1612">TZ 300W</option>
+<option value="1613">TZ 400</option>
+<option value="1614">TZ 400W</option>
+<option value="1615">TZ 500</option>
+<option value="1616">TZ 500W</option>
+<option value="1617">TZ 600</option>
+<option value="1618">NSA 2600</option>
+<option value="1619">NSA 2650</option>
+<option value="1620">NSA 3600</option>
+<option value="1621">NSA 3650</option>
+<option value="1622">NSA 4600</option>
+<option value="1623">NSA 4650</option>
+<option value="1624">NSA 5600</option>
+<option value="1625">NSA 5650</option>
+<option value="1626">NSA 6600</option>
+<option value="1627">NSA 6650</option>
+<option value="1628">SM 9200</option>
+<option value="1629">SM 9250</option>
+<option value="1630">SM 9400</option>
+<option value="1631">SM 9450</option>
+<option value="1632">SM 9600</option>
+<option value="1633">SM 9650</option>
+<option value="1634">TZ 300P</option>
+<option value="1635">TZ 600P</option>
+<option value="1636">SOHO 250</option>
+<option value="1637">SOHO 250W</option>
+<option value="1638">TZ 350</option>
+<option value="1639">TZ 350W</option>
+<option value="1640">EX4000 Series</option>
+<option value="1641">PrestaShop</option>
+<option value="1642">Azure Stack HCI</option>
+<option value="1643">vx-1000</option>
+<option value="1644">vx-2000</option>
+<option value="1645">vx-3000</option>
+<option value="1646">vx-500</option>
+<option value="1647">vx-5000</option>
+<option value="1648">vx-6000</option>
+<option value="1649">vx-7000</option>
+<option value="1650">vx-8000</option>
+<option value="1651">vx-9000</option>
+<option value="1652">nx-10700</option>
+<option value="1653">nx-11700</option>
+<option value="1654">nx-1700</option>
+<option value="1655">nx-2700</option>
+<option value="1656">nx-3700</option>
+<option value="1657">nx-5700</option>
+<option value="1658">nx-6700</option>
+<option value="1659">nx-700</option>
+<option value="1660">nx-7700</option>
+<option value="1661">nx-8700</option>
+<option value="1662">nx-9700</option>
+<option value="1663">Sierra Wireless ES450</option>
+<option value="1664">Sierra Wireless GX450</option>
+<option value="1666">AXIS A1001</option>
+<option value="1668">AXIS A1210 (-B)</option>
+<option value="1669">AXIS A1601</option>
+<option value="1670">AXIS A1610 (-B)</option>
+<option value="1671">AXIS A8207</option>
+<option value="1672">AXIS A8207 MKII</option>
+<option value="1673">Cisco Firepower 2110</option>
+<option value="1674">Cisco Firepower 2120</option>
+<option value="1675">Cisco Firepower 2130</option>
+<option value="1676">Cisco Firepower 2140</option>
+<option value="1678">nova227</option>
+<option value="1679">nova233</option>
+<option value="1680">nova243</option>
+<option value="1681">nova246</option>
+<option value="1682">ES450</option>
+<option value="1683">GX450</option>
+<option value="1687">EX4100 Series</option>
+<option value="1688">EX4400 Series</option>
+<option value="1689">Juniper ACX7024</option>
+<option value="1690">Nexo cordless nutrunner NXA011S-36V (0608842011)</option>
+<option value="1691">Nexo cordless nutrunner NXA011S-36V-B (0608842012)</option>
+<option value="1692">Nexo cordless nutrunner NXA015S-36V (0608842001)</option>
+<option value="1693">Nexo cordless nutrunner NXA015S-36V-B (0608842006)</option>
+<option value="1694">Nexo cordless nutrunner NXA030S-36V (0608842002)</option>
+<option value="1695">Nexo cordless nutrunner NXA030S-36V-B (0608842007)</option>
+<option value="1696">Nexo cordless nutrunner NXA050S-36V (0608842003)</option>
+<option value="1697">Nexo cordless nutrunner NXA050S-36V-B (0608842008)</option>
+<option value="1698">Nexo cordless nutrunner NXA065S-36V (0608842013)</option>
+<option value="1699">Nexo cordless nutrunner NXA065S-36V-B (0608842014)</option>
+<option value="1700">Nexo cordless nutrunner NXP012QD-36V (0608842005)</option>
+<option value="1701">Nexo cordless nutrunner NXP012QD-36V-B (0608842010)</option>
+<option value="1702">Nexo cordless nutrunner NXV012T-36V (0608842015)</option>
+<option value="1703">Nexo cordless nutrunner NXV012T-36V-B (0608842016)</option>
+<option value="1704">Nexo special cordless nutrunner (0608PE2272)</option>
+<option value="1705">Nexo special cordless nutrunner (0608PE2301)</option>
+<option value="1706">Nexo special cordless nutrunner (0608PE2514)</option>
+<option value="1707">Nexo special cordless nutrunner (0608PE2515)</option>
+<option value="1708">Nexo special cordless nutrunner (0608PE2666)</option>
+<option value="1709">Nexo special cordless nutrunner (0608PE2673)</option>
+<option value="1710">PAX A920Pro</option>
+<option value="1711">PAX A50</option>
+<option value="1712">PAX A6650</option>
+<option value="1713">PAX A800</option>
+<option value="1714">PAX A77</option>
+<option value="1715">PAX A920</option>
+<option value="1716">PAX A920Max</option>
+<option value="1717">PAX D190</option>
+<option value="1718">Intel E800</option>
+<option value="1719">IOS XRd Control Plane</option>
+<option value="1720">IOS XRd vRouter</option>
+<option value="1721">NCS 540 Series Routers</option>
+<option value="1722">NCS 5700 Series Routers</option>
+<option value="1724">Intel Wi-Fi 6E AX210</option>
+<option value="1725">Intel Wi-Fi 6E AX411</option>
+<option value="1726">Intel Killer Wi-Fi 6E AX1675</option>
+<option value="1727">Intel Killer Wi-Fi 6E AX1690</option>
+<option value="1729">Killer Wireless-AC 1550i</option>
+<option value="1730">Killer Wireless-AC 1550s</option>
+<option value="1731">Killer Wi-Fi 6E AX1690i</option>
+<option value="1732">Killer Wi-Fi 6E AX1690s</option>
+<option value="1733">Killer Wi-Fi 6E AX1675x</option>
+<option value="1734">Killer Wi-Fi 6E AX1675w</option>
+<option value="1735">Killer Wi-Fi 6E AX1675i</option>
+<option value="1736">Killer Wi-Fi 6E AX1675s</option>
+<option value="1737">Killer Wi-Fi 6 AX1650i</option>
+<option value="1738">Killer Wi-Fi 6 AX1650s</option>
+<option value="1739">Intel Wi-Fi 6 AX101</option>
+<option value="1740">Intel Wi-Fi 6 AX203</option>
+<option value="1741">Killer Wi-Fi 6 AX1650</option>
+<option value="1742">Killer Wireless-AC 1550</option>
+<option value="1743">Intel Wireless-N 7265</option>
+<option value="1744">Intel Dual Band Wireless-N 7265</option>
+<option value="1745">Intel Dual Band Wireless-AC 7265</option>
+<option value="1746">Cisco 2800 Series</option>
+<option value="1747">Cisco 2970 Series</option>
+<option value="1748">CentOS</option>
+<option value="1749">Debian 10 LTS</option>
+<option value="1750">DNA Traffic Telemetry Appliance</option>
+<option value="1751">Shell</option>
+<option value="1752">Vision Pro</option>
+<option value="1753">Aruba 5400R</option>
+<option value="1754">Aruba 3810</option>
+<option value="1755">Aruba 2920</option>
+<option value="1756">Aruba 2930F</option>
+<option value="1757">Aruba 2930M</option>
+<option value="1758">Aruba 2530</option>
+<option value="1759">Aruba 2540</option>
+<option value="1760">Aruba 3800</option>
+<option value="1761">Cisco UCS 6500</option>
+<option value="1762">6th Generation Intel Core processor</option>
+<option value="1763">9th Generation Intel Core processor</option>
+<option value="1764">Intel JHL8440 Thunderbolt 4</option>
+<option value="1765">Juniper SRX300 Series</option>
+<option value="1766">Cisco UCS C-Series M5 Rack Server</option>
+<option value="1767">Cisco UCS C-Series M4 Rack Server</option>
+<option value="1768">Cisco UCS C-Series M6 Rack Server</option>
+<option value="1769">Cisco UCS C-Series M7 Rack Server</option>
+<option value="1770">Cisco UCS E-Series M2</option>
+<option value="1771">Cisco UCS E-Series M3</option>
+<option value="1772">IEC6400 Edge Compute Appliances</option>
+<option value="1773">Secure Endpoint Private Cloud Appliances</option>
+<option value="1774">Secure Malware Analytics Appliances</option>
+<option value="1775">Secure Network Analytics Appliances</option>
+<option value="1776">Secure Network Server Appliances</option>
+<option value="1777">Telemetry Broker Appliances</option>
+<option value="1778">LG43UM7000PLA</option>
+<option value="1779">OLED55CXPUA</option>
+<option value="1780">OLED48C1PUB</option>
+<option value="1781">OLED55A23LA</option>
+<option value="1782">UCS E-Series M6 Server</option>
+<option value="1783">Cisco UCS S-Series Storage Server</option>
+<option value="1784">Cisco Firepower 9000 Series</option>
+<option value="1786">Cisco Secure Firewall 3100 Series</option>
+<option value="1787">Cisco Secure Firewall 4200 Series</option>
+<option value="1788">Cisco Secure Firewall Threat Defense Virtual</option>
+<option value="1789">Secure Firewall Management Center Appliances</option>
+<option value="1790">Extreme Networks AP30</option>
+<option value="1791">Extreme Networks AP122</option>
+<option value="1792">Extreme Networks AP122X</option>
+<option value="1793">Extreme Networks AP130</option>
+<option value="1794">Extreme Networks AP150W</option>
+<option value="1795">Extreme Networks AP230</option>
+<option value="1796">Extreme Networks AP245X</option>
+<option value="1797">Extreme Networks AP250</option>
+<option value="1798">Extreme Networks AP550</option>
+<option value="1799">Extreme Networks AP1130</option>
+<option value="1800">dp4400</option>
+<option value="1801">dp5900</option>
+<option value="1802">dd3300</option>
+<option value="1803">dd6400</option>
+<option value="1804">dd6900</option>
+<option value="1805">dd9400</option>
+<option value="1806">dd9900</option>
+<option value="1807">OS X</option>
+<option value="1808">Ubuntu</option>
+<option value="1809">Windows 11</option>
+<option value="1810">Windows 7</option>
+<option value="1811">Catalyst 8500L Edge</option>
+<option value="1812">Intel Kaby Lake</option>
+<option value="1813">Intel Coffee Lake</option>
+<option value="1814">Intel Ice Lake</option>
+<option value="1815">Intel Comet Lake</option>
+<option value="1816">Intel Tiger Lake</option>
+<option value="1817">Intel Jasper Lake</option>
+<option value="1818">Intel Alder Lake</option>
+<option value="1819">Intel Raptor Lake</option>
+<option value="1820">Intel Meteor Lake</option>
+<option value="1821">IFM QHA300</option>
+<option value="1822">IFM QHA210</option>
+<option value="1823">IFM QVA200</option>
+<option value="1824">aarch64</option>
+<option value="1825">ppc64le</option>
+<option value="1828">ACX7000</option>
+<option value="1829">AdTran SRG 834-5</option>
+<option value="1830">Nuvoton NPCM750R</option>
+<option value="1831">Nuvoton NPCM710R</option>
+<option value="1832">Nuvoton NPCM730R</option>
+<option value="1833">Nuvoton NPCM705R</option>
+<option value="1834">NCS 1010 Series Routers</option>
+<option value="1835">NCS 1014 Series Routers</option>
+<option value="1836">Intel Sandy Bridge</option>
+<option value="1837">SOHO (Gen 5)</option>
+<option value="1838">SM9800</option>
+<option value="1839">NSsp 12400</option>
+<option value="1840">NSsp 12800</option>
+<option value="1841">Fplus T1100</option>
+<option value="1842">Fplus T800</option>
+<option value="1844">HP 14-cf2xxx</option>
+<option value="1845">HP 14t-cf200</option>
+<option value="1846">HP 14-cf3xxx</option>
+<option value="1847">HP 14t-cf300</option>
+<option value="1848">HP 14-dq0xxx</option>
+<option value="1849">HP 14t-dq000</option>
+<option value="1850">HP 14-dq1xxx</option>
+<option value="1851">HP 14t-dq100</option>
+<option value="1852">HP 14-dq2xxx</option>
+<option value="1853">HP 14t-dq200</option>
+<option value="1854">HP 14-dq3xxx</option>
+<option value="1855">HP 14t-dq300</option>
+<option value="1856">HP 14-dq4xxx</option>
+<option value="1857">HP 14t-dq400</option>
+<option value="1858">HP 14-dq5xxx</option>
+<option value="1859">HP 14t-dq500</option>
+<option value="1860">HP 14-ee0xxx</option>
+<option value="1861">HP 14-em0xxx</option>
+<option value="1862">HP 14-ep0xxx</option>
+<option value="1863">HP 14-ep1xxx</option>
+<option value="1864">HP 14-gr0xxx</option>
+<option value="1865">HP 14-gr1xxx</option>
+<option value="1866">HP 14-hr0xxx</option>
+<option value="1867">HP 14-ma2xxx</option>
+<option value="1868">HP 14t-ma200</option>
+<option value="1869">HP 14-ma3xxx</option>
+<option value="1870">HP 14t-ma300</option>
+<option value="1871">HP 14s-cf2xxx</option>
+<option value="1872">HP 14s-cf3xxx</option>
+<option value="1873">HP 14s-cr2xxx</option>
+<option value="1874">HP 14s-cr3xxx</option>
+<option value="1875">HP 14s-cs2xxx</option>
+<option value="1876">HP 14s-cs3xxx</option>
+<option value="1877">HP 14s-dq0xxx</option>
+<option value="1878">HP 14s-dq1xxx</option>
+<option value="1879">HP 14s-dq2xxx</option>
+<option value="1880">HP 14s-dq3xxx</option>
+<option value="1881">HP 14s-dq4xxx</option>
+<option value="1882">HP 14s-dq5xxx</option>
+<option value="1883">HP 14s-dr0xxx</option>
+<option value="1884">HP 14s-dr1xxx</option>
+<option value="1885">HP 14s-dr2xxx</option>
+<option value="1886">HP 14s-dr3xxx</option>
+<option value="1887">HP 14s-dr4xxx</option>
+<option value="1888">HP 14s-dr5xxx</option>
+<option value="1889">HP 14s-dy0xxx</option>
+<option value="1890">HP 14s-dy1xxx</option>
+<option value="1891">HP 14s-dy2xxx</option>
+<option value="1892">HP 14s-dy3xxx</option>
+<option value="1893">HP 14s-dy4xxx</option>
+<option value="1894">HP 14s-dy5xxx</option>
+<option value="1895">HP 15-dy0xxx</option>
+<option value="1896">HP 15t-dy000</option>
+<option value="1897">HP 15-dy1xxx</option>
+<option value="1898">HP 15t-dy100</option>
+<option value="1899">HP 15-dy2xxx</option>
+<option value="1901">HP 15t-dy200</option>
+<option value="1902">HP 15-dy3xxx</option>
+<option value="1903">HP 15t-dy300</option>
+<option value="1904">HP 15-dy4xxx</option>
+<option value="1905">HP 15t-dy400</option>
+<option value="1906">HP 15-dy5xxx</option>
+<option value="1907">HP 15t-dy500</option>
+<option value="1908">HP 15-ef0xxx</option>
+<option value="1909">HP 15z-ef000</option>
+<option value="1910">HP 15-ef1xxx</option>
+<option value="1911">HP 15z-ef100</option>
+<option value="1912">HP 15-ef2xxx</option>
+<option value="1913">HP 15z-ef200</option>
+<option value="1914">HP 15-ef3xxx</option>
+<option value="1916">HP 15z-ef300</option>
+<option value="1917">HP 15-fc0xxx</option>
+<option value="1918">HP 15-fc1xxx</option>
+<option value="1919">HP 15-fd0xxx</option>
+<option value="1920">HP 15-fd1xxx</option>
+<option value="1921">HP 15-gw0xxx</option>
+<option value="1922">HP 15-hr0xxx</option>
+<option value="1923">HP 15-hr1xxx</option>
+<option value="1924">HP 15-kr0xxx</option>
+<option value="1925">HP 15-kr1xxx</option>
+<option value="1926">HP 15s-eq0xxx</option>
+<option value="1927">HP 15s-eq1xxx</option>
+<option value="1928">Node.js</option>
+<option value="1929">HP 15s-eq2xxx</option>
+<option value="1930">HP 15s-eq3xxx</option>
+<option value="1931">HP 15s-er0xxx</option>
+<option value="1932">HP 15s-er1xxx</option>
+<option value="1933">HP 15s-er2xxx</option>
+<option value="1934">HP 15s-er3xxx</option>
+<option value="1935">HP 15s-ey0xxx</option>
+<option value="1936">HP 15s-ey1xxx</option>
+<option value="1937">HP 15s-ey2xxx</option>
+<option value="1938">HP 15s-ey3xxx</option>
+<option value="1939">HP 15s-fq0xxx</option>
+<option value="1940">HP 15s-fq1xxx</option>
+<option value="1941">HP 15s-fq2xxx</option>
+<option value="1942">HP 15s-fq3xxx</option>
+<option value="1943">HP 15s-fq4xxx</option>
+<option value="1944">HP 15s-fq5xxx</option>
+<option value="1945">HP 15s-fr0xxx</option>
+<option value="1946">HP 15s-fr1xxx</option>
+<option value="1947">HP 15s-fr2xxx</option>
+<option value="1948">HP 15s-fr3xxx</option>
+<option value="1949">HP 15s-fr4xxx</option>
+<option value="1950">HP 15s-fr5xxx</option>
+<option value="1951">HP 15s-fy0xxx</option>
+<option value="1952">HP 15s-fy1xxx</option>
+<option value="1953">HP 15s-fy2xxx</option>
+<option value="1954">HP 15s-fy3xxx</option>
+<option value="1955">HP 15s-fy4xxx</option>
+<option value="1956">HP 15s-fy5xxx</option>
+<option value="1957">HP 15s-gr0xxx</option>
+<option value="1958">HP 15s-gu0xxx</option>
+<option value="1959">HP 15s-gy0xxx</option>
+<option value="1960">HP 17-cn1xxx</option>
+<option value="1961">HP 17t-cn100</option>
+<option value="1962">HP 17-cn2xxx</option>
+<option value="1963">HP 17t-cn200</option>
+<option value="1964">HP 17-cn3xxx</option>
+<option value="1965">HP 17-cn4xxx</option>
+<option value="1966">HP 17-cp0xxx</option>
+<option value="1967">HP 17z-cp000</option>
+<option value="1968">HP 17-cp1xxx</option>
+<option value="1969">HP 17z-cp100</option>
+<option value="1970">HP 17-cp2xxx</option>
+<option value="1971">HP 17-cp3xxx</option>
+<option value="1972">HP 17s-cr2xxx</option>
+<option value="1973">HP 17s-cr3xxx</option>
+<option value="1974">HP 17s-cr4xxx</option>
+<option value="1975">HP 17s-cu2xxx</option>
+<option value="1976">HP 17s-cu3xxx</option>
+<option value="1977">HP 17s-cy2xxx</option>
+<option value="1978">HP 17s-cy3xxx</option>
+<option value="1979">HP Envy 16-h0xxx</option>
+<option value="1980">HP 16t-h000</option>
+<option value="1981">HP Envy 16-h1xxx</option>
+<option value="1982">HP Envy 17-cr0xxx</option>
+<option value="1983">HP 17t-cr000</option>
+<option value="1984">HP Envy 17-cr1xxx</option>
+<option value="1985">HP Envy 17-cw0xxx</option>
+<option value="1986">HP Envy 17-cw1xxx</option>
+<option value="1987">HP Envy x360 13-bf0xxx</option>
+<option value="1988">HP Envy x360 13t-bf000</option>
+<option value="1989">HP Envy x360 14-es0xxx</option>
+<option value="1990">HP Envy x360 14-es1xxx</option>
+<option value="1991">HP Envy x360 15-eu0xxx</option>
+<option value="1992">HP Envy x360 15z-eu000</option>
+<option value="1993">HP Envy x360 15-ew0xxx</option>
+<option value="1994">HP Envy x360 15t-ew000</option>
+<option value="1995">HP Envy x360 15-ew1xxx</option>
+<option value="1996">HP Envy x360 15-ey0xxx</option>
+<option value="1997">HP Envy x360 15t-ey000</option>
+<option value="1998">HP Envy x360 15-ey1xxx</option>
+<option value="1999">HP Envy x360 15-fe0xxx</option>
+<option value="2000">HP Envy x360 15-fe1xxx</option>
+<option value="2001">HP Envy x360 15-fh0xxx</option>
+<option value="2002">HP Envy x360 15m-eu0xxx</option>
+<option value="2003">HP Pavilion 13-be0xxx</option>
+<option value="2004">HP Pavilion13z-be000</option>
+<option value="2005">HP Pavilion 15-eg0xxx</option>
+<option value="2006">HP Pavilion 15t-eg000</option>
+<option value="2007">HP Pavilion 15-eg1xxx</option>
+<option value="2008">HP Pavilion 15t-eg100</option>
+<option value="2009">HP Pavilion 15-eg2xxx</option>
+<option value="2010">HP Pavilion 15t-eg200</option>
+<option value="2011">HP Pavilion 15-eg3xxx</option>
+<option value="2012">HP Pavilion 15-eh0xxx</option>
+<option value="2013">HP Pavilion 15z-eh000</option>
+<option value="2014">HP Pavilion 15-eh1xxx</option>
+<option value="2015">HP Pavilion 15-eh2xxx</option>
+<option value="2016">HP Pavilion 15z-eh200</option>
+<option value="2017">HP Pavilion 15-eh3xxx</option>
+<option value="2018">HP Pavilion Aero 13-be1xxx</option>
+<option value="2019">HP Pavilion Aero 13z-be100</option>
+<option value="2020">HP Pavilion Aero 13-be2xxx</option>
+<option value="2021">HP Pavilion Plus 14-ew0xxx</option>
+<option value="2022">HP Pavilion Plus 14-ew1xxx</option>
+<option value="2023">HP Pavilion Plus 14-ey0xxx</option>
+<option value="2024">HP Pavilion Plus 14-ey1xxx</option>
+<option value="2025">HP Pavilion Plus 16-ab0xxx</option>
+<option value="2026">HP Pavilion Plus 16-ab1xxx</option>
+<option value="2027">HP Pavilion x360 14-ek0xxx</option>
+<option value="2028">HP Pavilion x360 14t-ek000</option>
+<option value="2029">HP Pavilion x360 14-ek1xxx</option>
+<option value="2030">HP Pavilion x360 14-ek2xxx</option>
+<option value="2031">HP Pavilion x360 15-er0xxx</option>
+<option value="2032">HP Pavilion x360 15t-er000</option>
+<option value="2033">HP Pavilion x360 15-er1xxx</option>
+<option value="2034">HP Pavilion x360 15t-er100</option>
+<option value="2035">HP Spectre x360 13-aw0xxx</option>
+<option value="2036">HP Spectre x360 14-eu0xxx</option>
+<option value="2037">HP Spectre x360 16-aa0xxx</option>
+<option value="2038">OMEN Gaming Laptop 15-fa0xxx</option>
+<option value="2039">OMEN Gaming Laptop 15t-fa000</option>
+<option value="2040">OMEN Gaming Laptop 16-wd0xxx</option>
+<option value="2041">OMEN Gaming Laptop 16-wf0xxx</option>
+<option value="2042">OMEN Gaming Laptop 16-wf1xxx</option>
+<option value="2043">OMEN Gaming Laptop 16-xd0xxx</option>
+<option value="2044">OMEN Gaming Laptop 16-xf0xxx</option>
+<option value="2045">OMEN Gaming Laptop 17-ck0xxx</option>
+<option value="2046">OMEN Gaming Laptop 17t-ck100</option>
+<option value="2047">OMEN Gaming Laptop 17-ck1xxx</option>
+<option value="2048">OMEN Gaming Laptop 17-ck2xxx</option>
+<option value="2049">OMEN Gaming Laptop 17-cm2xxx</option>
+<option value="2050">OMEN Transcend Gaming Laptop 16-u0xxx</option>
+<option value="2051">OMEN Transcend Gaming Laptop 16-u1xxx</option>
+<option value="2052">Victus Gaming Laptop 15-fa1xxx</option>
+<option value="2053">Victus Gaming Laptop 15-fb0xxx</option>
+<option value="2054">Victus Gaming Laptop 15z-fb000</option>
+<option value="2055">Victus Gaming Laptop 15-fb1xxx</option>
+<option value="2056">Victus Gaming Laptop 15-fb2xxx</option>
+<option value="2057">Victus Gaming Laptop 16-r0xxx</option>
+<option value="2058">Victus Gaming Laptop 16-r1xxx</option>
+<option value="2059">Victus Gaming Laptop 16-s0xxx</option>
+<option value="2060">Victus Gaming Laptop 16-s1xxx</option>
+<option value="2061">HP 240 G10 Notebook PC</option>
+<option value="2062">HP 240 G8 Notebook PC</option>
+<option value="2063">HP 240 G9 Notebook PC</option>
+<option value="2064">HP 240R G9 Notebook PC</option>
+<option value="2065">HP 245 G10 Notebook PC</option>
+<option value="2066">HP 250 G10 Notebook PC</option>
+<option value="2067">HP 250 G9 Notebook PC</option>
+<option value="2068">HP 255 G10 Notebook PC</option>
+<option value="2069">HP 255 G8 Notebook PC</option>
+<option value="2070">HP 255 G9 Notebook PC</option>
+<option value="2071">HP 340S G7 Notebook PC</option>
+<option value="2072">HP 350S G7 Notebook PC</option>
+<option value="2073">HP 470 G10 Notebook PC</option>
+<option value="2074">HP 470 G8 Notebook PC</option>
+<option value="2075">HP 470 G9 Notebook PC</option>
+<option value="2076">HP ZHAN 14 inch G6 Notebook PC</option>
+<option value="2077">HP ZHAN A 14 inch G6 Notebook PC</option>
+<option value="2078">HP ZHAN 14 inch G7 Notebook PC</option>
+<option value="2079">HP All-in-One Desktop 24-cr0xxxa</option>
+<option value="2080">HP Pavilion All-in-One 32-b0xxxi</option>
+<option value="2081">HP ProOne 240 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2082">HP ProOne 245 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2083">HP ZHAN 66 Pro A 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2084">NCS 540-24Q8L2DD-SYS Router</option>
+<option value="2085">NCS 540-24Z8Q2C-SYS Router</option>
+<option value="2086">NCS 540-28Z4C-SYS-A Router</option>
+<option value="2087">NCS 540-28Z4C-SYS-D Router</option>
+<option value="2088">NCS 540-ACC-SYS Router</option>
+<option value="2089">NCS 540X-16Z4G8Q2C-A Router</option>
+<option value="2090">NCS 540X-16Z4G8Q2C-D Router</option>
+<option value="2091">NCS 55A1-24Q6H-SS</option>
+<option value="2092">NCS 55A2-MOD-SE-S</option>
+<option value="2093">NCS-57C1-48Q6-SYS</option>
+<option value="2094">NCS 57C3-MOD</option>
+<option value="2095">Aruba 100 Series Access Points</option>
+<option value="2096">Aruba 103 Series Access Points</option>
+<option value="2097">Aruba 110 Series Access Points</option>
+<option value="2098">Aruba 120 Series Access Points</option>
+<option value="2099">Aruba 130 Series Access Points</option>
+<option value="2100">Aruba 200 Series Access Points</option>
+<option value="2101">Aruba 207 Series Access Points</option>
+<option value="2102">Aruba 210 Series Access Points</option>
+<option value="2103">Aruba 220 Series Access Points</option>
+<option value="2104">Aruba 260 Series Access Points</option>
+<option value="2105">Aruba 300 Series Access Points</option>
+<option value="2106">Aruba 303 Series Access Points</option>
+<option value="2107">Aruba 310 Series Access Points</option>
+<option value="2108">Aruba 320 Series Access Points</option>
+<option value="2109">Aruba 330 Series Access Points</option>
+<option value="2110">Aruba 340 Series Access Points</option>
+<option value="2111">Aruba 370 Series Access Points</option>
+<option value="2112">Aruba 500 Series Access Points</option>
+<option value="2113">Aruba 510 Series Access Points</option>
+<option value="2114">Aruba 530 Series Access Points</option>
+<option value="2115">Aruba 550 Series Access Points</option>
+<option value="2116">Aruba 630 Series Access Points</option>
+<option value="2117">Aruba 650 Series Access Points</option>
+<option value="2118">ASR9K-X64</option>
+<option value="2120">NCS 540L</option>
+<option value="2121">MX304 Series</option>
+<option value="2122">SRX5K</option>
+<option value="2123">S/390</option>
+<option value="2125">Catalyst 9300LM Series Switches</option>
+<option value="2126">Catalyst 9300X Series Switches</option>
+<option value="2127">Catalyst 9400X Supervisor Engines</option>
+<option value="2128">Catalyst 9500 High Performance Series Switches</option>
+<option value="2130">Harmony Industrial PC HMIBMO series</option>
+<option value="2131">Harmony Industrial PC HMIBMI series</option>
+<option value="2132">Harmony Industrial PC HMIPSO series</option>
+<option value="2133">Harmony Industrial PC HMIBMP series</option>
+<option value="2134">Harmony Industrial PC HMIBMU series</option>
+<option value="2135">Harmony Industrial PC HMIPSP series</option>
+<option value="2136">Harmony Industrial PC HMIPEP series</option>
+<option value="2137">Pro-face Industrial PC PS5000 series</option>
+<option value="2138">virtio-snd</option>
+<option value="2139">PA-800 Series</option>
+<option value="2145">UCS C-Series Servers in UCS Manager Mode</option>
+<option value="2146">UCS B-Series Servers in UCS Manager Mode</option>
+<option value="2147">UCS B-Series Servers in Intersight Management Mode</option>
+<option value="2148">UCS C-Series Servers in Intersight Management Mode</option>
+<option value="2149">UCS X-Series Servers in Intersight Management Mode</option>
+<option value="2150">UCS X-Series Servers in UCS Manager Mode</option>
+<option value="2151">PA-3200 Series</option>
+<option value="2152">PA-5200 Series</option>
+<option value="2153">PA-7000 Series</option>
+<option value="2154">Intel-based Mac systems</option>
+<option value="2155">11th Generation Intel Core Processor</option>
+<option value="2156">12th Generation Intel Core Processor</option>
+<option value="2157">Intel NUC M15 LAPRC710</option>
+<option value="2158">Intel NUC M15 LAPRC510</option>
+<option value="2159">Brocade 7810</option>
+<option value="2160">Brocade 7840</option>
+<option value="2161">Brocade 7850</option>
+<option value="2162">Brocade X6</option>
+<option value="2163">Brocade X7</option>
+<option value="2164">«Новая программно-аппаратная платформа»</option>
+<option value="2165">W461AS-EG</option>
+<option value="2166">W462AQ-EG</option>
+<option value="2167">W461AS</option>
+<option value="2168">W462AQ</option>
+<option value="2169">W461AS-EG S2</option>
+<option value="2170">W462AC-EG S2</option>
+<option value="2171">W461ASC</option>
+<option value="2172">TZ80</option>
+<option value="2173">RoomOS</option>
+<option value="2174">amd64</option>
+<option value="2175">AIX</option>
+<option value="2176">PowerStore 500T</option>
+<option value="2177">PowerStore 1000T</option>
+<option value="2178">PowerStore 1200T</option>
+<option value="2179">PowerStore 3000T</option>
+<option value="2180">PowerStore 3200T</option>
+<option value="2181">PowerStore 5000T</option>
+<option value="2182">PowerStore 5200T</option>
+<option value="2183">PowerStore 7000T</option>
+<option value="2184">PowerStore 9000T</option>
+<option value="2185">PowerStore 9200T</option>
+<option value="2186">Schneider Electric BMXNOR0200H</option>
+<option value="2187">Schneider Electric BMXNOE0110(H)</option>
+<option value="2188">Schneider Electric BMENOC0311(C)</option>
+<option value="2189">Schneider Electric BMENOC0321</option>
+<option value="2190">MPX</option>
+<option value="2191">PT MC</option>
+<option value="2192">Secure Endpoint Connector</option>
+<option value="2193">watsonx</option>
+<option value="2194">IBM Watsonx</option>
+<option value="2195">Spring Framework</option>
+<option value="2196">P550</option>
+<option value="2197">Azure Local</option>
+<option value="2198">R81</option>
+<option value="2199">R80</option>
+<option value="2200">R77</option>
+<option value="2201">R75</option>
+<option value="2202">710 Series</option>
+<option value="2203">720D Series</option>
+<option value="2204">720XP Series</option>
+<option value="2205">722XPM Series</option>
+<option value="2206">750X Series</option>
+<option value="2207">7010 Series</option>
+<option value="2208">7010X Series</option>
+<option value="2209">7020R Series</option>
+<option value="2210">7130 Series</option>
+<option value="2211">7150 Series</option>
+<option value="2212">7160 Series</option>
+<option value="2213">7170 Series</option>
+<option value="2214">7050X Series</option>
+<option value="2215">7050X2 Series</option>
+<option value="2216">7050X3 Series</option>
+<option value="2217">7050X4 Series</option>
+<option value="2218">7060X Series</option>
+<option value="2219">7060X2 Series</option>
+<option value="2220">7060X4 Series</option>
+<option value="2221">7060X5 Series</option>
+<option value="2222">7060X6 Series</option>
+<option value="2223">7250X Series</option>
+<option value="2224">7260X Series</option>
+<option value="2225">7260X3 Series</option>
+<option value="2226">7280E Series</option>
+<option value="2227">7280R Series</option>
+<option value="2228">7280R2 Series</option>
+<option value="2229">7280R3 Series</option>
+<option value="2230">7300X Series</option>
+<option value="2231">7300X3 Series</option>
+<option value="2232">7320X Series</option>
+<option value="2233">7358X4 Series</option>
+<option value="2234">7368X4 Series</option>
+<option value="2235">7388X5 Series</option>
+<option value="2236">7500E Series</option>
+<option value="2237">7500R Series</option>
+<option value="2238">7500R2 Series</option>
+<option value="2239">7500R3 Series</option>
+<option value="2240">7800R3 Series</option>
+<option value="2241">7800R4 Series</option>
+<option value="2242">7700R4 Series</option>
+<option value="2243">AWE 5000 Series</option>
+<option value="2244">AWE 7200R Series</option>
+<option value="2245">CloudEOS</option>
+<option value="2246">cEOS-lab</option>
+<option value="2247">vEOS-lab</option>
+<option value="2248">NCS 1004</option>
+<option value="2249">ASR 9000 Series Aggregation Services Routers (64-bit)</option>
+<option value="2250">8608 Routers</option>
+<option value="2251">8804 Routers</option>
+<option value="2252">8808 Routers</option>
+<option value="2253">8812 Routers</option>
+<option value="2254">8818 Routers</option>
+<option value="2255">NCS S5504</option>
+<option value="2256">NCS S5508</option>
+<option value="2257">NCS S5516</option>
+<option value="2258">1С-Битрикс</option>
+<option value="2259">1С-Битрикс: Управление сайтом</option>
+<option value="2260">IBM AIX</option>
+<option value="2261">IBM i</option>
+<option value="2262">IBM PowerLinux</option>
+<option value="2263">DSM 3.1</option>
+<option value="2264">DSM 7.2</option>
+<option value="2265">DSM 7.1</option>
+<option value="2266">DSM 6.2</option>
+<option value="2267">DSM 7.2.1</option>
+<option value="2268">DSM 7.2.2</option>
+<option value="2269">AS3000Simulator</option>
+<option value="2270">EX4650-48Y</option>
+<option value="2271">до версии 9 включительно</option>
+<option value="2273">--</option>
+<option value="2274">---</option>
+<option value="2275">Google Chrome</option>
+<option value="2276">Microsoft Edge</option>
+<option value="2277">Windows Desktop</option>
+<option value="2278">FortiGate 200F</option>
+<option value="2279">PowerStore 3200Q</option>
+<option value="2280">MediaTek MT6890</option>
+<option value="2281">MediaTek MT6990</option>
+<option value="2282">UCS C-Series M5</option>
+<option value="2283">SRX1600</option>
+<option value="2284">SRX2300</option>
+<option value="2285">C300 PCNT02</option>
+<option value="2286">EHB</option>
+<option value="2287">EHPM</option>
+<option value="2288">ELMM</option>
+<option value="2289">Classic ENIM</option>
+<option value="2290">ETN</option>
+<option value="2291">FIM4</option>
+<option value="2292">FIM8</option>
+<option value="2293">PGM</option>
+<option value="2294">RFIM</option>
+<option value="2295">arm64-SBSA</option>
+<option value="2296">x86_64</option>
+<option value="2297">x86</option>
+<option value="2298">Jetson Linux</option>
+<option value="2299">IGX OS</option>
+<option value="2300">NSV270</option>
+<option value="2301">NSv470</option>
+<option value="2302">NSv870</option>
+<option value="2303">«Бизнес»</option>
+<option value="2304">в редакции «Бизнес»</option>
+<option value="2305">в редакции «Корпорация»</option>
+<option value="2306">в редакции «Корпорация +»</option>
+<option value="2307">в редакции «Корпорация + ФСТЭК»</option>
+<option value="2308">Windows 10 IoT Enterprise LTSC 2021</option>
+<option value="2309">Windows 11 IoT Enterprise LTSC 2024</option>
+<option value="2310">Windows 11 Professional 2022</option>
+<option value="2311">Windows 10 Enterprise LTSC 21H2</option>
+<option value="2312">Windows 10 IoT Enterprise LTSC 2019</option>
+<option value="2313">Windows 10 IoT Enterprise LTSC 2021 for DN-PRP-HSR-I210 module</option>
+<option value="2314">Serial Interface and IO Controller</option>
+<option value="2315">Windows 10 IoT Enterprise LTSC 2021 for DE-PRP-HSR-EF module</option>
+<option value="2316">SerialInterface for Windows 10</option>
+<option value="2317">Windows 10 IoT Enterprise LTSC 2019/2021 for DE-2-IRIGB-4-DI/DO module</option>
+<option value="2318">Windows Server 2022</option>
+<option value="2319">Windows Server 2022 for expansion modules</option>
+<option value="2320">Windows 10 IoT Enterprise LTSC 2019 and Windows Server 2019</option>
+<option value="2321">DN-PRP-HSR-I210 module</option>
+<option value="2322">Windows 10 IoT Enterprise LTSC 2021 for DA-PRP-HSR-I210 module</option>
+<option value="2323">Windows 11 IoT Enterprise LTSC 2024 for Expansion Modules</option>
+<option value="2324">Windows 10 IoT Enterprise LTSC 2021 for Expansion Modules</option>
+<option value="2325">Tools for Windows Embedded Standard 7</option>
+<option value="2326">Windows 7 Embedded</option>
+<option value="2327">Windows 11 Enterprise LTSC 24H2</option>
+<option value="2328">Windows 11 Professional 2023</option>
+<option value="2329">SerialInterface</option>
+<option value="2330">MxOSD</option>
+<option value="2331">BlueField-2</option>
+<option value="2332">BlueField-3</option>
+<option value="2333">IOS XR White box (IOSXRWBD)</option>
+<option value="2334">NCS 560 Series Routers</option>
+<option value="2335">NCS 1000 Series</option>
+<option value="2336">NCS 1001 Series</option>
+<option value="2337">NCS 1002 Series</option>
+<option value="2338">NCS 1004 Series</option>
+<option value="2339">NCS 5000 Series Routers</option>
+<option value="2340">NCS 5500 Series Routers</option>
+<option value="2341">NCS 6000 Series Routers</option>
+<option value="2342">IOS XRd vRouters</option>
+<option value="2343">IOS XRv 9000 Routers</option>
+<option value="2344">Network Convergence Series (NCS) 540 Series Routers</option>
+<option value="2345">NCS 1010 Platforms</option>
+<option value="2346">NCS 1014 Platforms</option>
+<option value="2347">Dell Pro Rugged 13 RA13250</option>
+<option value="2348">Dell Pro Rugged 14 RB14250</option>
+<option value="2349">Latitude 5350</option>
+<option value="2350">Latitude 5450</option>
+<option value="2351">Latitude 5550</option>
+<option value="2352">Latitude 7030 Rugged Extreme Tablet</option>
+<option value="2353">Latitude 7350</option>
+<option value="2354">Latitude 7350 Detachable</option>
+<option value="2355">Latitude 7450</option>
+<option value="2356">Latitude 7650</option>
+<option value="2357">Latitude 9450 2-in-1</option>
+<option value="2358">Mobile Precision 3591</option>
+<option value="2359">Precision 3490</option>
+<option value="2360">Precision 3590</option>
+<option value="2361">User interface Tag</option>
+<option value="2362">Backend Tag</option>
+<option value="2363">UWP</option>
+<option value="2364">Desk Phone 9800 Series</option>
+<option value="2365">Cisco Video Phone 8875</option>
+<option value="2366">Global Android 13</option>
+<option value="2367">China Android 13</option>
+<option value="2368">Android 14</option>
+<option value="2369">Java</option>
+<option value="2370">SRX4700</option>
+<option value="2371">Azure Stack Hub</option>
+<option value="2372">XenServer</option>
+<option value="2373">Mediatek MT9972</option>
+<option value="2374">Mediatek МТ7915</option>
+<option value="2375">Mediatek MT7916</option>
+<option value="2376">Mediatek MT7981</option>
+<option value="2377">Mediatek MT7986</option>
+<option value="2378">TZ280</option>
+<option value="2379">TZ380</option>
+<option value="2380">TZ480</option>
+<option value="2381">TZ580</option>
+<option value="2382">TZ680</option>
+<option value="2383">NSa 2800</option>
+<option value="2384">NSa 3800</option>
+<option value="2385">NSa 4800</option>
+<option value="2386">NSa 5800</option>
+<option value="2387">ESX</option>
+<option value="2388">KVM</option>
+<option value="2389">HYPER-V</option>
+<option value="2390">AWS</option>
+<option value="2391">Azure</option>
+<option value="2392">MT7990</option>
+<option value="2393">Mediatek MT7990</option>
+<option value="2394">Mediatek MT7992</option>
+<option value="2395">ES Appliance 5000</option>
+<option value="2396">ES Appliance 5050</option>
+<option value="2397">ES Appliance 7000</option>
+<option value="2398">ES Appliance 7050</option>
+<option value="2399">ES Appliance 9000</option>
+<option value="2400">VMWare</option>
+<option value="2401">NVIDIA DGX OS</option>
+<option value="2402">0x95</option>
+<option value="2403">0x20</option>
+<option value="2404">0x01</option>
+<option value="2405">Z3</option>
+<option value="2406">Z4</option>
+<option value="2407">Z4C</option>
+<option value="2408">Z3C</option>
+<option value="2409">Meraki MX65</option>
+<option value="2410">Meraki MX65W</option>
+<option value="2411">Meraki MX75</option>
+<option value="2412">Meraki MX85</option>
+<option value="2413">Meraki MX95</option>
+<option value="2414">Meraki MX105</option>
+<option value="2415">Meraki MX400</option>
+<option value="2416">Meraki MX600</option>
+<option value="2417">Frontend административной части</option>
+<option value="2418">Frontend ученической части</option>
+<option value="2419">Backend</option>
+<option value="2420">FreeBSD</option>
+<option value="2421">TCIV</option>
+<option value="2422">for Python</option>
+<option value="2423">XR1000v2</option>
+<option value="2424">Astra Linux Special Edition 1.7</option>
+<option value="2425">Astra Linux Special Edition 1.8</option>
+<option value="2426">РЕД ОС 7.3</option>
+<option value="2427">Platform V SberLinux OS 8</option>
+<option value="2428">Platform V SberLinux OS 9</option>
+<option value="2429">Эльбрус</option>
+<option value="2430">от 4.6 до 4.9.336 включительно</option>
+<option value="2431">GB200</option>
+<option value="2432">GB300 (1.0)</option>
+<option value="2433">IBSwitch XDR</option>
+</select>    <div class="errorMessage" id="VulFilterForm_platf_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_version">Версия ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                          data-toggle="popover"
+                                                          data-content="Версия программного обеспечения, в которой обнаружена уязвимость, или программное обеспечение, подверженное уязвимости.<br/>
+                                                          Возможно использование следующих форматов:<br/>
+                            1) <b><i>«версия»</i></b> <small>– поиск уязвимостей, включающих введеную версию</small><br/>
+                            2) <b>от <i>«версия»</i></b> <small>или</small> <b><i>«версия» -</i></b> <small>– поиск уязвимостей, входящих в диапазон [<i>«версия»</i>;...]</small><br/>
+                            3) <b>до <i>«версия»</i></b> <small>или</small> <b><i>- «версия»</i></b> <small>– поиск уязвимостей, входящих в диапазон [...;<i>«версия»</i>]</small><br/>
+                            4) <b>от <i>«версия_1»</i> до <i>«версия_2»</i></b> <small>или</small> <b><i>«версия_1»</i> - <i>«версия_2»</i></b> <small>– поиск уязвимостей, входящих в диапазон [<i>«версия_1»</i>;<i>«версия_2»</i>]</small><br/>
+                            "></span>
+    <input name="VulFilterForm[version]" id="VulFilterForm_version" type="hidden" />    <div class="errorMessage" id="VulFilterForm_version_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_vul_state">Статус уязвимости</label>    <span class="glyphicon glyphicon-question-sign help-hint"
+                                                               data-toggle="popover"
+                                                               data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/50">Статус уязвимости</a> программного обеспечения'></span>
+    <select name="VulFilterForm[vul_state]" id="VulFilterForm_vul_state">
+<option value=""></option>
+<option value="0">Потенциальная уязвимость</option>
+<option value="1">Подтверждена производителем</option>
+<option value="2">Подтверждена в ходе исследований</option>
+</select>    <div class="errorMessage" id="VulFilterForm_vul_state_em_" style="display:none"></div></div>
+
+<div class="spoiler-btn">
+    <span class="glyphicon glyphicon-chevron-down"></span>Доп. параметры
+</div>
+
+<div class="spoiler">
+    <div class="spoiler-body in">
+        <div class="form-group">
+            <label for="VulFilterForm_dateRange">Диапазон дат</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                    data-toggle="popover"
+                                                                    data-content="Диапазон дат выявления уязвимостей"></span>
+            <div class="row">
+                <div class="col-sm-6 col-xs-6">
+                    <div class="input-group">
+                        <span class="input-group-addon">c</span>
+                        <input class="form-control input-sm" name="VulFilterForm[fromDate]" id="VulFilterForm_fromDate" type="text" />                    </div>
+                </div>
+                <div class="col-sm-6 col-xs-6">
+                    <div class="input-group">
+                        <span class="input-group-addon">по</span>
+                        <input class="form-control input-sm" name="VulFilterForm[toDate]" id="VulFilterForm_toDate" type="text" />                    </div>
+                </div>
+            </div>
+            <div class="errorMessage" id="VulFilterForm_toDate_em_" style="display:none"></div>        </div>
+                <!--        -->        <div class="form-group">
+            <input id="ytVulFilterForm_vul_incident" type="hidden" value="0" name="VulFilterForm[vul_incident]" /><input name="VulFilterForm[vul_incident]" id="VulFilterForm_vul_incident" value="1" type="checkbox" />            <label for="VulFilterForm_vul_incident">Уязвимости, связанные с инцидентами ИБ</label>            <span class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                  data-content='Показать только уязвимости программного обеспечения, связанные с инцидентами информационной безопасности'></span>
+            <div class="errorMessage" id="VulFilterForm_vul_incident_em_" style="display:none"></div>        </div>
+        <div class="form-group">
+            <input id="ytVulFilterForm_vul_extended_desc" type="hidden" value="0" name="VulFilterForm[vul_extended_desc]" /><input name="VulFilterForm[vul_extended_desc]" id="VulFilterForm_vul_extended_desc" value="1" type="checkbox" />            <label for="VulFilterForm_vul_extended_desc">Доступно расширенное описание</label>            <span class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                  data-content='Доступна информация, уточняющая описание уязвимости относительно каждого наименования уязвимого программного обеспечения'></span>
+            <div class="errorMessage" id="VulFilterForm_vul_extended_desc_em_" style="display:none"></div>        </div>
+        <div class="form-group">
+            <label for="VulFilterForm_yearAdd">Год добавления</label><span
+                    class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                    data-content='Год добавления записей об уязвимостях в Банк данных'></span>
+            <input empty="2026" name="VulFilterForm[yearAdd]" id="VulFilterForm_yearAdd" type="hidden" />            <div class="errorMessage" id="VulFilterForm_yearAdd_em_" style="display:none"></div>        </div>
+        <!--        -->        <div class="form-group">
+            <label for="VulFilterForm_clvul">Класс уязвимости</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                data-toggle="popover"
+                                                                data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/26">Класс уязвимости</a>, обнаруженной в программном обеспечении'></span>
+            <select name="VulFilterForm[clvul]" id="VulFilterForm_clvul">
+<option value=""></option>
+<option value="1">Уязвимость кода</option>
+<option value="3">Уязвимость архитектуры</option>
+<option value="6">Уязвимость многофакторная</option>
+</select>            <div class="errorMessage" id="VulFilterForm_clvul_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_bsLevel">Уровень опасности</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                  data-toggle="popover"
+                                                                  data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/56">Уровень опасности</a> обнаруженной уязвимости'></span>
+            <select name="VulFilterForm[bsLevel]" id="VulFilterForm_bsLevel">
+<option value=""></option>
+<option value="1">Низкий</option>
+<option value="2">Средний</option>
+<option value="3">Высокий</option>
+<option value="4">Критический</option>
+</select>            <div class="errorMessage" id="VulFilterForm_bsLevel_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_bsCVSS">Базовый вектор</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                 data-toggle="popover"
+                                                                 data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/5">Базовый вектор</a> общей системы оценки уязвимости CVSS v2.0'></span>
+            <div class="row">
+                <div class="col-xs-12">
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAV" name="VulFilterForm[bsAV]">
+<option value=""></option>
+<option value="L">L - Локальный</option>
+<option value="A">A - Смежная сеть</option>
+<option value="N">N - Сетевой</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAC" name="VulFilterForm[bsAC]">
+<option value=""></option>
+<option value="H">H - Высокая</option>
+<option value="M">M - Средняя</option>
+<option value="L">L - Низкая</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAu" name="VulFilterForm[bsAu]">
+<option value=""></option>
+<option value="M">M - Множественная</option>
+<option value="S">S - Единственная</option>
+<option value="N">N - Не требуется</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsC" name="VulFilterForm[bsC]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsI" name="VulFilterForm[bsI]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsA" name="VulFilterForm[bsA]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_cwe">Идентификатор типа ошибки</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                              data-toggle="popover"
+                                                              data-content="Идентификатор, установленный в соответствии с общим перечнем ошибок CWE"></span>
+            <select multiple="multiple" name="VulFilterForm[cwe][]" id="VulFilterForm_cwe">
+<option value="">Все идентификаторы</option>
+<option value="1">CWE-1</option>
+<option value="2">CWE-2</option>
+<option value="3">CWE-3</option>
+<option value="4">CWE-4</option>
+<option value="5">CWE-5</option>
+<option value="6">CWE-6</option>
+<option value="7">CWE-7</option>
+<option value="8">CWE-8</option>
+<option value="9">CWE-9</option>
+<option value="10">CWE-10</option>
+<option value="11">CWE-11</option>
+<option value="12">CWE-12</option>
+<option value="13">CWE-13</option>
+<option value="14">CWE-14</option>
+<option value="15">CWE-15</option>
+<option value="16">CWE-16</option>
+<option value="17">CWE-17</option>
+<option value="18">CWE-18</option>
+<option value="19">CWE-19</option>
+<option value="20">CWE-20</option>
+<option value="21">CWE-21</option>
+<option value="22">CWE-22</option>
+<option value="23">CWE-23</option>
+<option value="24">CWE-24</option>
+<option value="25">CWE-25</option>
+<option value="26">CWE-26</option>
+<option value="27">CWE-27</option>
+<option value="28">CWE-28</option>
+<option value="29">CWE-29</option>
+<option value="30">CWE-30</option>
+<option value="31">CWE-31</option>
+<option value="32">CWE-32</option>
+<option value="33">CWE-33</option>
+<option value="34">CWE-34</option>
+<option value="35">CWE-35</option>
+<option value="36">CWE-36</option>
+<option value="37">CWE-37</option>
+<option value="38">CWE-38</option>
+<option value="39">CWE-39</option>
+<option value="40">CWE-40</option>
+<option value="41">CWE-41</option>
+<option value="42">CWE-42</option>
+<option value="43">CWE-43</option>
+<option value="44">CWE-44</option>
+<option value="45">CWE-45</option>
+<option value="46">CWE-46</option>
+<option value="47">CWE-47</option>
+<option value="48">CWE-48</option>
+<option value="49">CWE-49</option>
+<option value="50">CWE-50</option>
+<option value="51">CWE-51</option>
+<option value="52">CWE-52</option>
+<option value="53">CWE-53</option>
+<option value="54">CWE-54</option>
+<option value="55">CWE-55</option>
+<option value="56">CWE-56</option>
+<option value="57">CWE-57</option>
+<option value="58">CWE-58</option>
+<option value="59">CWE-59</option>
+<option value="60">CWE-60</option>
+<option value="61">CWE-61</option>
+<option value="62">CWE-62</option>
+<option value="63">CWE-63</option>
+<option value="64">CWE-64</option>
+<option value="65">CWE-65</option>
+<option value="66">CWE-66</option>
+<option value="67">CWE-67</option>
+<option value="68">CWE-68</option>
+<option value="69">CWE-69</option>
+<option value="70">CWE-70</option>
+<option value="71">CWE-71</option>
+<option value="72">CWE-72</option>
+<option value="73">CWE-73</option>
+<option value="74">CWE-74</option>
+<option value="75">CWE-75</option>
+<option value="76">CWE-76</option>
+<option value="77">CWE-77</option>
+<option value="78">CWE-78</option>
+<option value="79">CWE-79</option>
+<option value="80">CWE-80</option>
+<option value="81">CWE-81</option>
+<option value="82">CWE-82</option>
+<option value="83">CWE-83</option>
+<option value="84">CWE-84</option>
+<option value="85">CWE-85</option>
+<option value="86">CWE-86</option>
+<option value="87">CWE-87</option>
+<option value="88">CWE-88</option>
+<option value="89">CWE-89</option>
+<option value="90">CWE-90</option>
+<option value="91">CWE-91</option>
+<option value="92">CWE-92</option>
+<option value="93">CWE-93</option>
+<option value="94">CWE-94</option>
+<option value="95">CWE-95</option>
+<option value="96">CWE-96</option>
+<option value="97">CWE-97</option>
+<option value="98">CWE-98</option>
+<option value="99">CWE-99</option>
+<option value="100">CWE-100</option>
+<option value="101">CWE-101</option>
+<option value="102">CWE-102</option>
+<option value="103">CWE-103</option>
+<option value="104">CWE-104</option>
+<option value="105">CWE-105</option>
+<option value="106">CWE-106</option>
+<option value="107">CWE-107</option>
+<option value="108">CWE-108</option>
+<option value="109">CWE-109</option>
+<option value="110">CWE-110</option>
+<option value="111">CWE-111</option>
+<option value="112">CWE-112</option>
+<option value="113">CWE-113</option>
+<option value="114">CWE-114</option>
+<option value="115">CWE-115</option>
+<option value="116">CWE-116</option>
+<option value="117">CWE-117</option>
+<option value="118">CWE-118</option>
+<option value="119">CWE-119</option>
+<option value="120">CWE-120</option>
+<option value="121">CWE-121</option>
+<option value="122">CWE-122</option>
+<option value="123">CWE-123</option>
+<option value="124">CWE-124</option>
+<option value="125">CWE-125</option>
+<option value="126">CWE-126</option>
+<option value="127">CWE-127</option>
+<option value="128">CWE-128</option>
+<option value="129">CWE-129</option>
+<option value="130">CWE-130</option>
+<option value="131">CWE-131</option>
+<option value="132">CWE-132</option>
+<option value="133">CWE-133</option>
+<option value="134">CWE-134</option>
+<option value="135">CWE-135</option>
+<option value="136">CWE-136</option>
+<option value="137">CWE-137</option>
+<option value="138">CWE-138</option>
+<option value="139">CWE-139</option>
+<option value="140">CWE-140</option>
+<option value="141">CWE-141</option>
+<option value="142">CWE-142</option>
+<option value="143">CWE-143</option>
+<option value="144">CWE-144</option>
+<option value="145">CWE-145</option>
+<option value="146">CWE-146</option>
+<option value="147">CWE-147</option>
+<option value="148">CWE-148</option>
+<option value="149">CWE-149</option>
+<option value="150">CWE-150</option>
+<option value="151">CWE-151</option>
+<option value="152">CWE-152</option>
+<option value="153">CWE-153</option>
+<option value="154">CWE-154</option>
+<option value="155">CWE-155</option>
+<option value="156">CWE-156</option>
+<option value="157">CWE-157</option>
+<option value="158">CWE-158</option>
+<option value="159">CWE-159</option>
+<option value="160">CWE-160</option>
+<option value="161">CWE-161</option>
+<option value="162">CWE-162</option>
+<option value="163">CWE-163</option>
+<option value="164">CWE-164</option>
+<option value="165">CWE-165</option>
+<option value="166">CWE-166</option>
+<option value="167">CWE-167</option>
+<option value="168">CWE-168</option>
+<option value="169">CWE-169</option>
+<option value="170">CWE-170</option>
+<option value="171">CWE-171</option>
+<option value="172">CWE-172</option>
+<option value="173">CWE-173</option>
+<option value="174">CWE-174</option>
+<option value="175">CWE-175</option>
+<option value="176">CWE-176</option>
+<option value="177">CWE-177</option>
+<option value="178">CWE-178</option>
+<option value="179">CWE-179</option>
+<option value="180">CWE-180</option>
+<option value="181">CWE-181</option>
+<option value="182">CWE-182</option>
+<option value="183">CWE-183</option>
+<option value="184">CWE-184</option>
+<option value="185">CWE-185</option>
+<option value="186">CWE-186</option>
+<option value="187">CWE-187</option>
+<option value="188">CWE-188</option>
+<option value="189">CWE-189</option>
+<option value="190">CWE-190</option>
+<option value="191">CWE-191</option>
+<option value="192">CWE-192</option>
+<option value="193">CWE-193</option>
+<option value="194">CWE-194</option>
+<option value="195">CWE-195</option>
+<option value="196">CWE-196</option>
+<option value="197">CWE-197</option>
+<option value="198">CWE-198</option>
+<option value="199">CWE-199</option>
+<option value="200">CWE-200</option>
+<option value="201">CWE-201</option>
+<option value="202">CWE-202</option>
+<option value="203">CWE-203</option>
+<option value="204">CWE-204</option>
+<option value="205">CWE-205</option>
+<option value="206">CWE-206</option>
+<option value="207">CWE-207</option>
+<option value="208">CWE-208</option>
+<option value="209">CWE-209</option>
+<option value="210">CWE-210</option>
+<option value="211">CWE-211</option>
+<option value="212">CWE-212</option>
+<option value="213">CWE-213</option>
+<option value="214">CWE-214</option>
+<option value="215">CWE-215</option>
+<option value="216">CWE-216</option>
+<option value="217">CWE-217</option>
+<option value="218">CWE-218</option>
+<option value="219">CWE-219</option>
+<option value="220">CWE-220</option>
+<option value="221">CWE-221</option>
+<option value="222">CWE-222</option>
+<option value="223">CWE-223</option>
+<option value="224">CWE-224</option>
+<option value="225">CWE-225</option>
+<option value="226">CWE-226</option>
+<option value="227">CWE-227</option>
+<option value="228">CWE-228</option>
+<option value="229">CWE-229</option>
+<option value="230">CWE-230</option>
+<option value="231">CWE-231</option>
+<option value="232">CWE-232</option>
+<option value="233">CWE-233</option>
+<option value="234">CWE-234</option>
+<option value="235">CWE-235</option>
+<option value="236">CWE-236</option>
+<option value="237">CWE-237</option>
+<option value="238">CWE-238</option>
+<option value="239">CWE-239</option>
+<option value="240">CWE-240</option>
+<option value="241">CWE-241</option>
+<option value="242">CWE-242</option>
+<option value="243">CWE-243</option>
+<option value="244">CWE-244</option>
+<option value="245">CWE-245</option>
+<option value="246">CWE-246</option>
+<option value="247">CWE-247</option>
+<option value="248">CWE-248</option>
+<option value="249">CWE-249</option>
+<option value="250">CWE-250</option>
+<option value="251">CWE-251</option>
+<option value="252">CWE-252</option>
+<option value="253">CWE-253</option>
+<option value="254">CWE-254</option>
+<option value="255">CWE-255</option>
+<option value="256">CWE-256</option>
+<option value="257">CWE-257</option>
+<option value="258">CWE-258</option>
+<option value="259">CWE-259</option>
+<option value="260">CWE-260</option>
+<option value="261">CWE-261</option>
+<option value="262">CWE-262</option>
+<option value="263">CWE-263</option>
+<option value="264">CWE-264</option>
+<option value="265">CWE-265</option>
+<option value="266">CWE-266</option>
+<option value="267">CWE-267</option>
+<option value="268">CWE-268</option>
+<option value="269">CWE-269</option>
+<option value="270">CWE-270</option>
+<option value="271">CWE-271</option>
+<option value="272">CWE-272</option>
+<option value="273">CWE-273</option>
+<option value="274">CWE-274</option>
+<option value="275">CWE-275</option>
+<option value="276">CWE-276</option>
+<option value="277">CWE-277</option>
+<option value="278">CWE-278</option>
+<option value="279">CWE-279</option>
+<option value="280">CWE-280</option>
+<option value="281">CWE-281</option>
+<option value="282">CWE-282</option>
+<option value="283">CWE-283</option>
+<option value="284">CWE-284</option>
+<option value="285">CWE-285</option>
+<option value="286">CWE-286</option>
+<option value="287">CWE-287</option>
+<option value="288">CWE-288</option>
+<option value="289">CWE-289</option>
+<option value="290">CWE-290</option>
+<option value="291">CWE-291</option>
+<option value="292">CWE-292</option>
+<option value="293">CWE-293</option>
+<option value="294">CWE-294</option>
+<option value="295">CWE-295</option>
+<option value="296">CWE-296</option>
+<option value="297">CWE-297</option>
+<option value="298">CWE-298</option>
+<option value="299">CWE-299</option>
+<option value="300">CWE-300</option>
+<option value="301">CWE-301</option>
+<option value="302">CWE-302</option>
+<option value="303">CWE-303</option>
+<option value="304">CWE-304</option>
+<option value="305">CWE-305</option>
+<option value="306">CWE-306</option>
+<option value="307">CWE-307</option>
+<option value="308">CWE-308</option>
+<option value="309">CWE-309</option>
+<option value="310">CWE-310</option>
+<option value="311">CWE-311</option>
+<option value="312">CWE-312</option>
+<option value="313">CWE-313</option>
+<option value="314">CWE-314</option>
+<option value="315">CWE-315</option>
+<option value="316">CWE-316</option>
+<option value="317">CWE-317</option>
+<option value="318">CWE-318</option>
+<option value="319">CWE-319</option>
+<option value="320">CWE-320</option>
+<option value="321">CWE-321</option>
+<option value="322">CWE-322</option>
+<option value="323">CWE-323</option>
+<option value="324">CWE-324</option>
+<option value="325">CWE-325</option>
+<option value="326">CWE-326</option>
+<option value="327">CWE-327</option>
+<option value="328">CWE-328</option>
+<option value="329">CWE-329</option>
+<option value="330">CWE-330</option>
+<option value="331">CWE-331</option>
+<option value="332">CWE-332</option>
+<option value="333">CWE-333</option>
+<option value="334">CWE-334</option>
+<option value="335">CWE-335</option>
+<option value="336">CWE-336</option>
+<option value="337">CWE-337</option>
+<option value="338">CWE-338</option>
+<option value="339">CWE-339</option>
+<option value="340">CWE-340</option>
+<option value="341">CWE-341</option>
+<option value="342">CWE-342</option>
+<option value="343">CWE-343</option>
+<option value="344">CWE-344</option>
+<option value="345">CWE-345</option>
+<option value="346">CWE-346</option>
+<option value="347">CWE-347</option>
+<option value="348">CWE-348</option>
+<option value="349">CWE-349</option>
+<option value="350">CWE-350</option>
+<option value="351">CWE-351</option>
+<option value="352">CWE-352</option>
+<option value="353">CWE-353</option>
+<option value="354">CWE-354</option>
+<option value="355">CWE-355</option>
+<option value="356">CWE-356</option>
+<option value="357">CWE-357</option>
+<option value="358">CWE-358</option>
+<option value="359">CWE-359</option>
+<option value="360">CWE-360</option>
+<option value="361">CWE-361</option>
+<option value="362">CWE-362</option>
+<option value="363">CWE-363</option>
+<option value="364">CWE-364</option>
+<option value="365">CWE-365</option>
+<option value="366">CWE-366</option>
+<option value="367">CWE-367</option>
+<option value="368">CWE-368</option>
+<option value="369">CWE-369</option>
+<option value="370">CWE-370</option>
+<option value="371">CWE-371</option>
+<option value="372">CWE-372</option>
+<option value="373">CWE-373</option>
+<option value="374">CWE-374</option>
+<option value="375">CWE-375</option>
+<option value="376">CWE-376</option>
+<option value="377">CWE-377</option>
+<option value="378">CWE-378</option>
+<option value="379">CWE-379</option>
+<option value="380">CWE-380</option>
+<option value="381">CWE-381</option>
+<option value="382">CWE-382</option>
+<option value="383">CWE-383</option>
+<option value="384">CWE-384</option>
+<option value="385">CWE-385</option>
+<option value="386">CWE-386</option>
+<option value="387">CWE-387</option>
+<option value="388">CWE-388</option>
+<option value="389">CWE-389</option>
+<option value="390">CWE-390</option>
+<option value="391">CWE-391</option>
+<option value="392">CWE-392</option>
+<option value="393">CWE-393</option>
+<option value="394">CWE-394</option>
+<option value="395">CWE-395</option>
+<option value="396">CWE-396</option>
+<option value="397">CWE-397</option>
+<option value="398">CWE-398</option>
+<option value="399">CWE-399</option>
+<option value="400">CWE-400</option>
+<option value="401">CWE-401</option>
+<option value="402">CWE-402</option>
+<option value="403">CWE-403</option>
+<option value="404">CWE-404</option>
+<option value="405">CWE-405</option>
+<option value="406">CWE-406</option>
+<option value="407">CWE-407</option>
+<option value="408">CWE-408</option>
+<option value="409">CWE-409</option>
+<option value="410">CWE-410</option>
+<option value="411">CWE-411</option>
+<option value="412">CWE-412</option>
+<option value="413">CWE-413</option>
+<option value="414">CWE-414</option>
+<option value="415">CWE-415</option>
+<option value="416">CWE-416</option>
+<option value="417">CWE-417</option>
+<option value="418">CWE-418</option>
+<option value="419">CWE-419</option>
+<option value="420">CWE-420</option>
+<option value="421">CWE-421</option>
+<option value="422">CWE-422</option>
+<option value="423">CWE-423</option>
+<option value="424">CWE-424</option>
+<option value="425">CWE-425</option>
+<option value="426">CWE-426</option>
+<option value="427">CWE-427</option>
+<option value="428">CWE-428</option>
+<option value="429">CWE-429</option>
+<option value="430">CWE-430</option>
+<option value="431">CWE-431</option>
+<option value="432">CWE-432</option>
+<option value="433">CWE-433</option>
+<option value="434">CWE-434</option>
+<option value="435">CWE-435</option>
+<option value="436">CWE-436</option>
+<option value="437">CWE-437</option>
+<option value="438">CWE-438</option>
+<option value="439">CWE-439</option>
+<option value="440">CWE-440</option>
+<option value="441">CWE-441</option>
+<option value="442">CWE-442</option>
+<option value="443">CWE-443</option>
+<option value="444">CWE-444</option>
+<option value="445">CWE-445</option>
+<option value="446">CWE-446</option>
+<option value="447">CWE-447</option>
+<option value="448">CWE-448</option>
+<option value="449">CWE-449</option>
+<option value="450">CWE-450</option>
+<option value="451">CWE-451</option>
+<option value="452">CWE-452</option>
+<option value="453">CWE-453</option>
+<option value="454">CWE-454</option>
+<option value="455">CWE-455</option>
+<option value="456">CWE-456</option>
+<option value="457">CWE-457</option>
+<option value="458">CWE-458</option>
+<option value="459">CWE-459</option>
+<option value="460">CWE-460</option>
+<option value="461">CWE-461</option>
+<option value="462">CWE-462</option>
+<option value="463">CWE-463</option>
+<option value="464">CWE-464</option>
+<option value="465">CWE-465</option>
+<option value="466">CWE-466</option>
+<option value="467">CWE-467</option>
+<option value="468">CWE-468</option>
+<option value="469">CWE-469</option>
+<option value="470">CWE-470</option>
+<option value="471">CWE-471</option>
+<option value="472">CWE-472</option>
+<option value="473">CWE-473</option>
+<option value="474">CWE-474</option>
+<option value="475">CWE-475</option>
+<option value="476">CWE-476</option>
+<option value="477">CWE-477</option>
+<option value="478">CWE-478</option>
+<option value="479">CWE-479</option>
+<option value="480">CWE-480</option>
+<option value="481">CWE-481</option>
+<option value="482">CWE-482</option>
+<option value="483">CWE-483</option>
+<option value="484">CWE-484</option>
+<option value="485">CWE-485</option>
+<option value="486">CWE-486</option>
+<option value="487">CWE-487</option>
+<option value="488">CWE-488</option>
+<option value="489">CWE-489</option>
+<option value="490">CWE-490</option>
+<option value="491">CWE-491</option>
+<option value="492">CWE-492</option>
+<option value="493">CWE-493</option>
+<option value="494">CWE-494</option>
+<option value="495">CWE-495</option>
+<option value="496">CWE-496</option>
+<option value="497">CWE-497</option>
+<option value="498">CWE-498</option>
+<option value="499">CWE-499</option>
+<option value="500">CWE-500</option>
+<option value="501">CWE-501</option>
+<option value="502">CWE-502</option>
+<option value="503">CWE-503</option>
+<option value="504">CWE-504</option>
+<option value="505">CWE-505</option>
+<option value="506">CWE-506</option>
+<option value="507">CWE-507</option>
+<option value="508">CWE-508</option>
+<option value="509">CWE-509</option>
+<option value="510">CWE-510</option>
+<option value="511">CWE-511</option>
+<option value="512">CWE-512</option>
+<option value="513">CWE-513</option>
+<option value="514">CWE-514</option>
+<option value="515">CWE-515</option>
+<option value="516">CWE-516</option>
+<option value="517">CWE-517</option>
+<option value="518">CWE-518</option>
+<option value="519">CWE-519</option>
+<option value="520">CWE-520</option>
+<option value="521">CWE-521</option>
+<option value="522">CWE-522</option>
+<option value="523">CWE-523</option>
+<option value="524">CWE-524</option>
+<option value="525">CWE-525</option>
+<option value="526">CWE-526</option>
+<option value="527">CWE-527</option>
+<option value="528">CWE-528</option>
+<option value="529">CWE-529</option>
+<option value="530">CWE-530</option>
+<option value="531">CWE-531</option>
+<option value="532">CWE-532</option>
+<option value="533">CWE-533</option>
+<option value="534">CWE-534</option>
+<option value="535">CWE-535</option>
+<option value="536">CWE-536</option>
+<option value="537">CWE-537</option>
+<option value="538">CWE-538</option>
+<option value="539">CWE-539</option>
+<option value="540">CWE-540</option>
+<option value="541">CWE-541</option>
+<option value="542">CWE-542</option>
+<option value="543">CWE-543</option>
+<option value="544">CWE-544</option>
+<option value="545">CWE-545</option>
+<option value="546">CWE-546</option>
+<option value="547">CWE-547</option>
+<option value="548">CWE-548</option>
+<option value="549">CWE-549</option>
+<option value="550">CWE-550</option>
+<option value="551">CWE-551</option>
+<option value="552">CWE-552</option>
+<option value="553">CWE-553</option>
+<option value="554">CWE-554</option>
+<option value="555">CWE-555</option>
+<option value="556">CWE-556</option>
+<option value="557">CWE-557</option>
+<option value="558">CWE-558</option>
+<option value="559">CWE-559</option>
+<option value="560">CWE-560</option>
+<option value="561">CWE-561</option>
+<option value="562">CWE-562</option>
+<option value="563">CWE-563</option>
+<option value="564">CWE-564</option>
+<option value="565">CWE-565</option>
+<option value="566">CWE-566</option>
+<option value="567">CWE-567</option>
+<option value="568">CWE-568</option>
+<option value="569">CWE-569</option>
+<option value="570">CWE-570</option>
+<option value="571">CWE-571</option>
+<option value="572">CWE-572</option>
+<option value="573">CWE-573</option>
+<option value="574">CWE-574</option>
+<option value="575">CWE-575</option>
+<option value="576">CWE-576</option>
+<option value="577">CWE-577</option>
+<option value="578">CWE-578</option>
+<option value="579">CWE-579</option>
+<option value="580">CWE-580</option>
+<option value="581">CWE-581</option>
+<option value="582">CWE-582</option>
+<option value="583">CWE-583</option>
+<option value="584">CWE-584</option>
+<option value="585">CWE-585</option>
+<option value="586">CWE-586</option>
+<option value="587">CWE-587</option>
+<option value="588">CWE-588</option>
+<option value="589">CWE-589</option>
+<option value="590">CWE-590</option>
+<option value="591">CWE-591</option>
+<option value="592">CWE-592</option>
+<option value="593">CWE-593</option>
+<option value="594">CWE-594</option>
+<option value="595">CWE-595</option>
+<option value="596">CWE-596</option>
+<option value="597">CWE-597</option>
+<option value="598">CWE-598</option>
+<option value="599">CWE-599</option>
+<option value="600">CWE-600</option>
+<option value="601">CWE-601</option>
+<option value="602">CWE-602</option>
+<option value="603">CWE-603</option>
+<option value="604">CWE-604</option>
+<option value="605">CWE-605</option>
+<option value="606">CWE-606</option>
+<option value="607">CWE-607</option>
+<option value="608">CWE-608</option>
+<option value="609">CWE-609</option>
+<option value="610">CWE-610</option>
+<option value="611">CWE-611</option>
+<option value="612">CWE-612</option>
+<option value="613">CWE-613</option>
+<option value="614">CWE-614</option>
+<option value="615">CWE-615</option>
+<option value="616">CWE-616</option>
+<option value="617">CWE-617</option>
+<option value="618">CWE-618</option>
+<option value="619">CWE-619</option>
+<option value="620">CWE-620</option>
+<option value="621">CWE-621</option>
+<option value="622">CWE-622</option>
+<option value="623">CWE-623</option>
+<option value="624">CWE-624</option>
+<option value="625">CWE-625</option>
+<option value="626">CWE-626</option>
+<option value="627">CWE-627</option>
+<option value="628">CWE-628</option>
+<option value="629">CWE-629</option>
+<option value="630">CWE-630</option>
+<option value="631">CWE-631</option>
+<option value="632">CWE-632</option>
+<option value="633">CWE-633</option>
+<option value="634">CWE-634</option>
+<option value="635">CWE-635</option>
+<option value="636">CWE-636</option>
+<option value="637">CWE-637</option>
+<option value="638">CWE-638</option>
+<option value="639">CWE-639</option>
+<option value="640">CWE-640</option>
+<option value="641">CWE-641</option>
+<option value="642">CWE-642</option>
+<option value="643">CWE-643</option>
+<option value="644">CWE-644</option>
+<option value="645">CWE-645</option>
+<option value="646">CWE-646</option>
+<option value="647">CWE-647</option>
+<option value="648">CWE-648</option>
+<option value="649">CWE-649</option>
+<option value="650">CWE-650</option>
+<option value="651">CWE-651</option>
+<option value="652">CWE-652</option>
+<option value="653">CWE-653</option>
+<option value="654">CWE-654</option>
+<option value="655">CWE-655</option>
+<option value="656">CWE-656</option>
+<option value="657">CWE-657</option>
+<option value="658">CWE-658</option>
+<option value="659">CWE-659</option>
+<option value="660">CWE-660</option>
+<option value="661">CWE-661</option>
+<option value="662">CWE-662</option>
+<option value="663">CWE-663</option>
+<option value="664">CWE-664</option>
+<option value="665">CWE-665</option>
+<option value="666">CWE-666</option>
+<option value="667">CWE-667</option>
+<option value="668">CWE-668</option>
+<option value="669">CWE-669</option>
+<option value="670">CWE-670</option>
+<option value="671">CWE-671</option>
+<option value="672">CWE-672</option>
+<option value="673">CWE-673</option>
+<option value="674">CWE-674</option>
+<option value="675">CWE-675</option>
+<option value="676">CWE-676</option>
+<option value="677">CWE-677</option>
+<option value="678">CWE-678</option>
+<option value="679">CWE-679</option>
+<option value="680">CWE-680</option>
+<option value="681">CWE-681</option>
+<option value="682">CWE-682</option>
+<option value="683">CWE-683</option>
+<option value="684">CWE-684</option>
+<option value="685">CWE-685</option>
+<option value="686">CWE-686</option>
+<option value="687">CWE-687</option>
+<option value="688">CWE-688</option>
+<option value="689">CWE-689</option>
+<option value="690">CWE-690</option>
+<option value="691">CWE-691</option>
+<option value="692">CWE-692</option>
+<option value="693">CWE-693</option>
+<option value="694">CWE-694</option>
+<option value="695">CWE-695</option>
+<option value="696">CWE-696</option>
+<option value="697">CWE-697</option>
+<option value="698">CWE-698</option>
+<option value="699">CWE-699</option>
+<option value="700">CWE-700</option>
+<option value="701">CWE-701</option>
+<option value="702">CWE-702</option>
+<option value="703">CWE-703</option>
+<option value="704">CWE-704</option>
+<option value="705">CWE-705</option>
+<option value="706">CWE-706</option>
+<option value="707">CWE-707</option>
+<option value="708">CWE-708</option>
+<option value="709">CWE-709</option>
+<option value="710">CWE-710</option>
+<option value="711">CWE-711</option>
+<option value="712">CWE-712</option>
+<option value="713">CWE-713</option>
+<option value="714">CWE-714</option>
+<option value="715">CWE-715</option>
+<option value="716">CWE-716</option>
+<option value="717">CWE-717</option>
+<option value="718">CWE-718</option>
+<option value="719">CWE-719</option>
+<option value="720">CWE-720</option>
+<option value="721">CWE-721</option>
+<option value="722">CWE-722</option>
+<option value="723">CWE-723</option>
+<option value="724">CWE-724</option>
+<option value="725">CWE-725</option>
+<option value="726">CWE-726</option>
+<option value="727">CWE-727</option>
+<option value="728">CWE-728</option>
+<option value="729">CWE-729</option>
+<option value="730">CWE-730</option>
+<option value="731">CWE-731</option>
+<option value="732">CWE-732</option>
+<option value="733">CWE-733</option>
+<option value="734">CWE-734</option>
+<option value="735">CWE-735</option>
+<option value="736">CWE-736</option>
+<option value="737">CWE-737</option>
+<option value="738">CWE-738</option>
+<option value="739">CWE-739</option>
+<option value="740">CWE-740</option>
+<option value="741">CWE-741</option>
+<option value="742">CWE-742</option>
+<option value="743">CWE-743</option>
+<option value="744">CWE-744</option>
+<option value="745">CWE-745</option>
+<option value="746">CWE-746</option>
+<option value="747">CWE-747</option>
+<option value="748">CWE-748</option>
+<option value="749">CWE-749</option>
+<option value="750">CWE-750</option>
+<option value="751">CWE-751</option>
+<option value="752">CWE-752</option>
+<option value="753">CWE-753</option>
+<option value="754">CWE-754</option>
+<option value="755">CWE-755</option>
+<option value="756">CWE-756</option>
+<option value="757">CWE-757</option>
+<option value="758">CWE-758</option>
+<option value="759">CWE-759</option>
+<option value="760">CWE-760</option>
+<option value="761">CWE-761</option>
+<option value="762">CWE-762</option>
+<option value="763">CWE-763</option>
+<option value="764">CWE-764</option>
+<option value="765">CWE-765</option>
+<option value="766">CWE-766</option>
+<option value="767">CWE-767</option>
+<option value="768">CWE-768</option>
+<option value="769">CWE-769</option>
+<option value="770">CWE-770</option>
+<option value="771">CWE-771</option>
+<option value="772">CWE-772</option>
+<option value="773">CWE-773</option>
+<option value="774">CWE-774</option>
+<option value="775">CWE-775</option>
+<option value="776">CWE-776</option>
+<option value="777">CWE-777</option>
+<option value="778">CWE-778</option>
+<option value="779">CWE-779</option>
+<option value="780">CWE-780</option>
+<option value="781">CWE-781</option>
+<option value="782">CWE-782</option>
+<option value="783">CWE-783</option>
+<option value="784">CWE-784</option>
+<option value="785">CWE-785</option>
+<option value="786">CWE-786</option>
+<option value="787">CWE-787</option>
+<option value="788">CWE-788</option>
+<option value="789">CWE-789</option>
+<option value="790">CWE-790</option>
+<option value="791">CWE-791</option>
+<option value="792">CWE-792</option>
+<option value="793">CWE-793</option>
+<option value="794">CWE-794</option>
+<option value="795">CWE-795</option>
+<option value="796">CWE-796</option>
+<option value="797">CWE-797</option>
+<option value="798">CWE-798</option>
+<option value="799">CWE-799</option>
+<option value="800">CWE-800</option>
+<option value="801">CWE-801</option>
+<option value="802">CWE-802</option>
+<option value="803">CWE-803</option>
+<option value="804">CWE-804</option>
+<option value="805">CWE-805</option>
+<option value="806">CWE-806</option>
+<option value="807">CWE-807</option>
+<option value="808">CWE-808</option>
+<option value="809">CWE-809</option>
+<option value="810">CWE-810</option>
+<option value="811">CWE-811</option>
+<option value="812">CWE-812</option>
+<option value="813">CWE-813</option>
+<option value="814">CWE-814</option>
+<option value="815">CWE-815</option>
+<option value="816">CWE-816</option>
+<option value="817">CWE-817</option>
+<option value="818">CWE-818</option>
+<option value="819">CWE-819</option>
+<option value="820">CWE-820</option>
+<option value="821">CWE-821</option>
+<option value="822">CWE-822</option>
+<option value="823">CWE-823</option>
+<option value="824">CWE-824</option>
+<option value="825">CWE-825</option>
+<option value="826">CWE-826</option>
+<option value="827">CWE-827</option>
+<option value="828">CWE-828</option>
+<option value="829">CWE-829</option>
+<option value="830">CWE-830</option>
+<option value="831">CWE-831</option>
+<option value="832">CWE-832</option>
+<option value="833">CWE-833</option>
+<option value="834">CWE-834</option>
+<option value="835">CWE-835</option>
+<option value="836">CWE-836</option>
+<option value="837">CWE-837</option>
+<option value="838">CWE-838</option>
+<option value="839">CWE-839</option>
+<option value="840">CWE-840</option>
+<option value="841">CWE-841</option>
+<option value="842">CWE-842</option>
+<option value="843">CWE-843</option>
+<option value="844">CWE-844</option>
+<option value="845">CWE-845</option>
+<option value="846">CWE-846</option>
+<option value="847">CWE-847</option>
+<option value="848">CWE-848</option>
+<option value="849">CWE-849</option>
+<option value="850">CWE-850</option>
+<option value="851">CWE-851</option>
+<option value="852">CWE-852</option>
+<option value="853">CWE-853</option>
+<option value="854">CWE-854</option>
+<option value="855">CWE-855</option>
+<option value="856">CWE-856</option>
+<option value="857">CWE-857</option>
+<option value="858">CWE-858</option>
+<option value="859">CWE-859</option>
+<option value="860">CWE-860</option>
+<option value="861">CWE-861</option>
+<option value="862">CWE-862</option>
+<option value="863">CWE-863</option>
+<option value="864">CWE-864</option>
+<option value="865">CWE-865</option>
+<option value="866">CWE-866</option>
+<option value="867">CWE-867</option>
+<option value="868">CWE-868</option>
+<option value="869">CWE-869</option>
+<option value="870">CWE-870</option>
+<option value="871">CWE-871</option>
+<option value="872">CWE-872</option>
+<option value="873">CWE-873</option>
+<option value="874">CWE-874</option>
+<option value="875">CWE-875</option>
+<option value="876">CWE-876</option>
+<option value="877">CWE-877</option>
+<option value="878">CWE-878</option>
+<option value="879">CWE-879</option>
+<option value="880">CWE-880</option>
+<option value="881">CWE-881</option>
+<option value="882">CWE-882</option>
+<option value="883">CWE-883</option>
+<option value="884">CWE-884</option>
+<option value="885">CWE-885</option>
+<option value="886">CWE-886</option>
+<option value="887">CWE-887</option>
+<option value="888">CWE-888</option>
+<option value="889">CWE-889</option>
+<option value="890">CWE-890</option>
+<option value="891">CWE-891</option>
+<option value="892">CWE-892</option>
+<option value="893">CWE-893</option>
+<option value="894">CWE-894</option>
+<option value="895">CWE-895</option>
+<option value="896">CWE-896</option>
+<option value="897">CWE-897</option>
+<option value="898">CWE-898</option>
+<option value="899">CWE-899</option>
+<option value="900">CWE-900</option>
+<option value="901">CWE-901</option>
+<option value="902">CWE-902</option>
+<option value="903">CWE-903</option>
+<option value="904">CWE-904</option>
+<option value="905">CWE-905</option>
+<option value="906">CWE-906</option>
+<option value="907">CWE-907</option>
+<option value="908">CWE-908</option>
+<option value="909">CWE-909</option>
+<option value="910">CWE-910</option>
+<option value="911">CWE-911</option>
+<option value="912">CWE-912</option>
+<option value="913">CWE-913</option>
+<option value="914">CWE-914</option>
+<option value="915">CWE-915</option>
+<option value="916">CWE-916</option>
+<option value="917">CWE-917</option>
+<option value="918">CWE-918</option>
+<option value="919">CWE-919</option>
+<option value="920">CWE-920</option>
+<option value="921">CWE-921</option>
+<option value="922">CWE-922</option>
+<option value="923">CWE-923</option>
+<option value="924">CWE-924</option>
+<option value="925">CWE-925</option>
+<option value="926">CWE-926</option>
+<option value="927">CWE-927</option>
+<option value="928">CWE-928</option>
+<option value="929">CWE-929</option>
+<option value="930">CWE-930</option>
+<option value="931">CWE-931</option>
+<option value="932">CWE-932</option>
+<option value="933">CWE-933</option>
+<option value="934">CWE-934</option>
+<option value="935">CWE-935</option>
+<option value="936">CWE-936</option>
+<option value="937">CWE-937</option>
+<option value="938">CWE-938</option>
+<option value="1001">CWE-943</option>
+<option value="1002">CWE-941</option>
+<option value="1003">CWE-1103</option>
+<option value="1004">CWE-942</option>
+<option value="1005">CWE-1188</option>
+<option value="1006">CWE-1021</option>
+<option value="1007">CWE-1236</option>
+<option value="1008">CWE-1321</option>
+<option value="1009">CWE-939</option>
+<option value="1010">CWE-1050</option>
+<option value="1011">CWE-1284</option>
+<option value="1012">CWE-1287</option>
+<option value="1013">CWE-1112</option>
+<option value="1014">CWE-1300</option>
+<option value="1015">CWE-1283</option>
+<option value="1016">CWE-1037</option>
+<option value="1017">CWE-1286</option>
+<option value="1018">CWE-1333</option>
+<option value="1019">CWE-1285</option>
+<option value="1022">CWE-1275</option>
+<option value="1023">CWE-1288</option>
+<option value="1024">CWE-1059</option>
+<option value="1025">CWE-1326</option>
+<option value="1026">CWE-1247</option>
+<option value="1027">CWE-1250</option>
+<option value="1028">CWE-1263</option>
+<option value="1029">CWE-1320</option>
+<option value="1030">CWE-1015</option>
+<option value="1031">CWE-1393</option>
+<option value="1032">CWE-1327</option>
+<option value="1033">CWE-1342</option>
+<option value="1034">CWE-1068</option>
+<option value="1035">CWE-1004</option>
+<option value="1036">CWE-1173</option>
+<option value="1037">CWE-1077</option>
+<option value="1038">CWE-1390</option>
+<option value="1039">CWE-1336</option>
+<option value="1040">CWE-1386</option>
+<option value="1041">CWE-1259</option>
+<option value="1042">CWE-1334</option>
+<option value="1043">CWE-1281</option>
+<option value="1044">CWE-1104</option>
+<option value="1045">CWE-1392</option>
+<option value="1046">CWE-1018</option>
+<option value="1047">CWE-1125</option>
+<option value="1048">CWE-1039</option>
+<option value="1049">CWE-940</option>
+<option value="1050">CWE-1269</option>
+<option value="1051">CWE-1385</option>
+<option value="1052">CWE-1220</option>
+<option value="1053">CWE-1262</option>
+<option value="1054">CWE-1395</option>
+<option value="1055">CWE-1191</option>
+<option value="1056">CWE-1303</option>
+<option value="1057">CWE-1394</option>
+<option value="1058">CWE-1423</option>
+<option value="1059">CWE-1107</option>
+<option value="1060">CWE-1389</option>
+<option value="1061">CWE-1251</option>
+<option value="1062">CWE-1245</option>
+<option value="1063">CWE-1391</option>
+<option value="1064">CWE-1189</option>
+<option value="1065">CWE-1325</option>
+<option value="1066">CWE-1025</option>
+<option value="1067">CWE-1295</option>
+<option value="1068">CWE-1298</option>
+<option value="1069">CWE-1242</option>
+<option value="1070">CWE-1297</option>
+<option value="1071">CWE-1230</option>
+<option value="1072">CWE-1222</option>
+<option value="1073">CWE-1335</option>
+<option value="1074">CWE-1341</option>
+<option value="1075">CWE-1023</option>
+<option value="1076">CWE-1289</option>
+<option value="1077">CWE-1277</option>
+<option value="1078">CWE-1384</option>
+<option value="1079">CWE-1244</option>
+<option value="1080">CWE-1258</option>
+<option value="1081">CWE-1264</option>
+<option value="1082">CWE-1240</option>
+<option value="1083">CWE-1256</option>
+<option value="1084">CWE-1322</option>
+<option value="1085">CWE-1100</option>
+<option value="1086">CWE-1257</option>
+<option value="1087">CWE-1164</option>
+<option value="1088">CWE-1419</option>
+<option value="1089">CWE-1233</option>
+<option value="1090">CWE-1102</option>
+<option value="1091">CWE-1176</option>
+<option value="1092">CWE-1426</option>
+<option value="1093">CWE-1060</option>
+<option value="1094">CWE-1120</option>
+<option value="1095">CWE-1260</option>
+<option value="1096">CWE-1422</option>
+<option value="1097">CWE-1022</option>
+<option value="1098">CWE-1329</option>
+<option value="1099">CWE-1177</option>
+<option value="1100">CWE-1231</option>
+<option value="1101">CWE-1091</option>
+<option value="1102">CWE-1108</option>
+<option value="1103">CWE-1006</option>
+<option value="1104">CWE-1211</option>
+</select>            <div class="errorMessage" id="VulFilterForm_cwe_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_idval">Другие системы идентификации</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                data-toggle="popover"
+                                                                data-content="Идентификаторы других систем учета уязвимостей"></span>
+            <input empty="All idents" multiple="multiple" name="VulFilterForm[idval]" id="VulFilterForm_idval" type="hidden" />            <div class="errorMessage" id="VulFilterForm_idval_em_" style="display:none"></div>        </div>
+
+
+        
+        <div class="form-group">
+            <label for="VulFilterForm_vul_expl">Наличие эксплойта</label>            <select name="VulFilterForm[vul_expl]" id="VulFilterForm_vul_expl">
+<option value=""></option>
+<option value="0">Данные уточняются</option>
+<option value="1">Существует</option>
+<option value="2">Существует в открытом доступе</option>
+</select>            <div class="errorMessage" id="VulFilterForm_vul_expl_em_" style="display:none"></div>        </div>
+
+
+        <div class="form-group">
+            <label for="VulFilterForm_operProc">Способ эксплуатации</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                   data-toggle="popover"
+                                                                   data-content="Способ эксплуатации уязвимости"></span>
+            <select name="VulFilterForm[operProc]" id="VulFilterForm_operProc">
+<option value=""></option>
+<option value="1">Несанкционированный сбор информации</option>
+<option value="2">Исчерпание ресурсов</option>
+<option value="3">Инъекция</option>
+<option value="4">Анализ целевого объекта</option>
+<option value="5">Подмена при взаимодействии</option>
+<option value="6">Злоупотребление функционалом</option>
+<option value="7">Нарушение авторизации</option>
+<option value="8">Нарушение аутентификации</option>
+<option value="9">Манипулирование структурами данных</option>
+<option value="10">Манипулирование ресурсами</option>
+<option value="11">Манипулирование сроками и состоянием</option>
+<option value="12">Вероятностные методы</option>
+</select>            <div class="errorMessage" id="VulFilterForm_operProc_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_vul_elimination">Способ устранения</label><span
+                    class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                    data-content="Способ устранения уязвимости"></span>
+            <select name="VulFilterForm[vul_elimination]" id="VulFilterForm_vul_elimination">
+<option value=""></option>
+<option value="0">Данные уточняются</option>
+<option value="1">Обновление программного обеспечения</option>
+<option value="2">Организационные меры</option>
+</select>            <div class="errorMessage" id="VulFilterForm_vul_elimination_em_" style="display:none"></div>        </div>
+
+
+        <div class="form-group">
+            <label for="VulFilterForm_osystem">Операционная система</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                  data-toggle="popover"
+                                                                  data-content="Операционная система, под управлением которой функционирует программное обеспечение с обнаруженной уязвимостью"></span>
+            <input name="VulFilterForm[osystem]" id="VulFilterForm_osystem" type="hidden" />            <div class="errorMessage" id="VulFilterForm_osystem_em_" style="display:none"></div>        </div>
+    </div>
+</div>
+
+
+<div class="form-group text-center">
+    <input name="clear" class="btn btn-default" type="submit" value="Сброс" />    <input name="fl" class="btn btn-success" type="submit" value="Применить" /></div>
+
+</form><script>
+    var webroot = "";
+</script>
+
+</div>
+</div>    </div>
+    <div class="col-sm-12 col-md-3 col-lg-3">
+        <div class="portlet" id="yw3">
+<div class="portlet-decoration">
+<div class="portlet-right-decoration-inner">
+<div class="portlet-title">Последние изменения</div>
+</div>
+</div>
+<div class="portlet-content">
+<ul class="list-news">
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03438">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с неограниченным распределением ресурсов, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03437">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с использованием имени с неправильной ссылкой, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03436">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с непринятием мер по защите структуры веб-страницы, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03435">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с обходом аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю получить несанкционированный доступ к защищаемой информации</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03434">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03433">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с распределением ресурсов без ограничений или регулирования, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03432">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связанная с использованием регулярного выражения с неэффективной вычислительной сложностью, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03431">Уязвимость интерфейса Mermaid UI программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03430">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03429">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab Enterprise Edition (EE), связанная с обходом процедуры аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю обойти существующие механизмы безопасности</a>	</li>
+	</ul>
+
+</div>
+</div>    </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="footer">
+        <div class="portlet-full summary" id="yw4">
+<div class="portlet-content">
+<p>Угрозы: <span class="badge">227</span> Уязвимости: <span class="badge">84542</span> Последнее обновление: <span class="badge">20.03.2026</span></p>
+</div>
+</div>        		<p class="text-center">&copy; ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;</p>
+        <div id="counters" class="text-left">
+                            <!-- Yandex.Metrika informer -->
+                <a href="https://metrika.yandex.ru/stat/?id=28243701&amp;from=informer"
+                   target="_blank" rel="nofollow noopener noreferrer"><img src="https://informer.yandex.ru/informer/28243701/3_0_707070FF_505050FF_1_pageviews"
+                                                       style="width:88px; height:31px; border:0;" alt="Яндекс.Метрика" title="Яндекс.Метрика: данные за сегодня (просмотры, визиты и уникальные посетители)" class="ym-advanced-informer" data-cid="28243701" data-lang="ru" /></a>
+                <!-- /Yandex.Metrika informer -->
+
+                <!-- Yandex.Metrika counter -->
+                <script type="text/javascript" >
+                    (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+                        m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+                    (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+                    ym(28243701, "init", {
+                        clickmap:true,
+                        trackLinks:true,
+                        accurateTrackBounce:true
+                    });
+                </script>
+                <noscript><div><img src="https://mc.yandex.ru/watch/28243701" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+                <!-- /Yandex.Metrika counter -->
+                    </div>
+    </div>
+
+    <script src="/themes/fstec/js/bootstrap.min.js"></script>
+    <script src="/themes/fstec/js/affix.js"></script>
+    <script>
+        $(function(){
+            $('#top-nav').affix({
+                offset: {
+                    top: $('.page-header').outerHeight(true)
+                }
+            });
+        })
+        window.onload = function () {
+        document.body.classList.add('loaded_hiding');
+        window.setTimeout(function () {
+            document.body.classList.add('loaded');
+            document.body.classList.remove('loaded_hiding');
+        }, 500);
+
+        document.getElementsByTagName('body')[0].onclick = function (e) {
+            let target = e && e.target || event.srcElement;
+            if(e.ctrlKey === true || e.shiftKey === true || e.altKey === true)
+                return;
+            if (target.tagName === "A" || target.tagName === "INPUT") {
+                if (target?.classList.contains('dropdown-toggle')
+                    || target?.classList.contains('toggle')
+                    || target?.classList.contains('dropdown')
+                    || target?.hash !== undefined && target?.hash !== ""
+                    || target?.href !== undefined && target?.href.includes('#')
+                    || target?.href !== undefined && target?.href.includes('blob:')
+                    || target?.href !== undefined && target?.href.includes('/site/agreement')
+                    || target?.href !== undefined && target?.href.includes('/bdu_public.key')
+                    || target?.href !== undefined && target?.href.includes('/files/')
+                    || target?.href !== undefined && target?.href.includes('/education')
+                    || target?.href !== undefined && target?.href.includes('/education/')
+                    || target?.href !== undefined && target?.href.includes('/software-section')
+                    || target?.href !== undefined && target?.href.includes('/software-section/')
+                    || target?.href !== undefined && target?.href.includes('/threat-section')
+                    || target?.href !== undefined && target?.href.includes('/threat-section/')
+                    || target?.href !== undefined && target?.href.includes('/mailing-profiles')
+                    || target?.href !== undefined && target?.href.includes('/mailing-profiles/')
+                    || target?.href !== undefined && target?.href === ""
+                    || target?.download !== undefined && target?.download !== ""
+                    || target.tagName === "INPUT" && target.type !== "submit") {
+                    return;
+                }
+                if (target.target !== "_blank" || target.type === "submit") {
+                    $(document).on("ajaxComplete", function (event, xhr, settings) {
+                        document.body.classList.add('loaded_hiding');
+                        window.setTimeout(function () {
+                            document.body.classList.add('loaded');
+                            document.body.classList.remove('loaded_hiding');
+                        }, 500);
+                    });
+                    document.body.classList.remove('loaded');
+                }
+            }
+        }
+    }
+    </script>
+
+
+    <script type="text/javascript" src="/assets/d68f76a4/listview/jquery.yiilistview.js"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+jQuery(function($) {
+jQuery('#vuls').yiiListView({'ajaxUpdate':['vuls'],'ajaxVar':'ajax','pagerClass':'link\x2Dpager','loadingClass':'list\x2Dview\x2Dloading','sorterClass':'sorter','enableHistory':false,'afterAjaxUpdate': function(){setVulsTooltip()}});
+jQuery('#vul-filter-form').yiiactiveform({'validateOnSubmit':false,'validateOnChange':false,'validateOnType':false,'attributes':[{'id':'VulFilterForm_vendor','inputID':'VulFilterForm_vendor','errorID':'VulFilterForm_vendor_em_','model':'VulFilterForm','name':'vendor','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_softType','inputID':'VulFilterForm_softType','errorID':'VulFilterForm_softType_em_','model':'VulFilterForm','name':'softType','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_soft','inputID':'VulFilterForm_soft','errorID':'VulFilterForm_soft_em_','model':'VulFilterForm','name':'soft','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_platf','inputID':'VulFilterForm_platf','errorID':'VulFilterForm_platf_em_','model':'VulFilterForm','name':'platf','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_version','inputID':'VulFilterForm_version','errorID':'VulFilterForm_version_em_','model':'VulFilterForm','name':'version','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_state','inputID':'VulFilterForm_vul_state','errorID':'VulFilterForm_vul_state_em_','model':'VulFilterForm','name':'vul_state','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_toDate','inputID':'VulFilterForm_toDate','errorID':'VulFilterForm_toDate_em_','model':'VulFilterForm','name':'toDate','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_incident','inputID':'VulFilterForm_vul_incident','errorID':'VulFilterForm_vul_incident_em_','model':'VulFilterForm','name':'vul_incident','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_extended_desc','inputID':'VulFilterForm_vul_extended_desc','errorID':'VulFilterForm_vul_extended_desc_em_','model':'VulFilterForm','name':'vul_extended_desc','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_yearAdd','inputID':'VulFilterForm_yearAdd','errorID':'VulFilterForm_yearAdd_em_','model':'VulFilterForm','name':'yearAdd','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_clvul','inputID':'VulFilterForm_clvul','errorID':'VulFilterForm_clvul_em_','model':'VulFilterForm','name':'clvul','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_bsLevel','inputID':'VulFilterForm_bsLevel','errorID':'VulFilterForm_bsLevel_em_','model':'VulFilterForm','name':'bsLevel','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_cwe','inputID':'VulFilterForm_cwe','errorID':'VulFilterForm_cwe_em_','model':'VulFilterForm','name':'cwe','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_idval','inputID':'VulFilterForm_idval','errorID':'VulFilterForm_idval_em_','model':'VulFilterForm','name':'idval','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_expl','inputID':'VulFilterForm_vul_expl','errorID':'VulFilterForm_vul_expl_em_','model':'VulFilterForm','name':'vul_expl','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_operProc','inputID':'VulFilterForm_operProc','errorID':'VulFilterForm_operProc_em_','model':'VulFilterForm','name':'operProc','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_elimination','inputID':'VulFilterForm_vul_elimination','errorID':'VulFilterForm_vul_elimination_em_','model':'VulFilterForm','name':'vul_elimination','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_osystem','inputID':'VulFilterForm_osystem','errorID':'VulFilterForm_osystem_em_','model':'VulFilterForm','name':'osystem','enableAjaxValidation':true,'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true}],'summaryID':'vul\x2Dfilter\x2Dform_es_','errorCss':'error'});
+});
+/*]]>*/
+</script>
+</body>
+</html>

--- a/tests/unit/sbom_pipeline/enrichters/html_notfound.html
+++ b/tests/unit/sbom_pipeline/enrichters/html_notfound.html
@@ -1,0 +1,4165 @@
+HTTP/1.1 200 OK
+content-type: text/html; charset=UTF-8
+date: Sun, 22 Mar 2026 20:55:22 GMT
+expires: Thu, 19 Nov 1981 08:52:00 GMT
+cache-control: no-store, no-cache, must-revalidate
+pragma: no-cache
+content-security-policy-report-only: default-src 'self' informer.yandex.ru mc.yandex.ru;
+strict-transport-security: max-age=31536000; includeSubDomains
+x-content-type-options: nosniff
+referrer-policy: origin
+x-frame-options: SAMEORIGIN
+set-cookie: PHPSESSID=4fdc2b64dccaa4c9b327746e862a691d; path=/; secure; HttpOnly; SameSite=Strict
+Content-Length: 217487
+
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="/themes/fstec/css/datepicker/bootstrap-datepicker.css" />
+<link rel="stylesheet" type="text/css" href="/themes/fstec/css/select2/select2.css" />
+<link rel="stylesheet" type="text/css" href="/assets/d68f76a4/listview/styles.css" />
+<script type="text/javascript" src="/js/jquery.min.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/datepicker/bootstrap-datepicker.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/datepicker/locales/bootstrap-datepicker.ru.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/cookie/jquery.cookie.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/select2/select2.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/libs/select2/select2_locale_ru.js"></script>
+<script type="text/javascript" src="/themes/fstec/js/ubi/vul/index.js"></script>
+<script type="text/javascript" src="/assets/79fc5d5a/jquery.ba-bbq.min.js"></script>
+<script type="text/javascript" src="/assets/79fc5d5a/jquery.yiiactiveform.js"></script>
+<title>БДУ - Уязвимости</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name='yandex-verification' content='6e77e36010cdf1ed' />
+    <meta name="base-url" content=""/>
+    <link rel="stylesheet" href="/themes/fstec/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/themes/fstec/css/style.css">
+
+
+    <!--[if lt IE 9]>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <script src="/themes/fstec/js/html5shiv.js"></script>
+        <script src="/themes/fstec/js/respond.min.js"></script>
+    <![endif]-->
+    <style>
+        .preloader {
+            position: fixed;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            background-image: radial-gradient(#ffffff, #757575);
+            opacity: 0.6;
+            z-index: 1001;
+        }
+        .preloader__row {
+            position: relative;
+            top: 50%;
+            left: 50%;
+            width: 34px;
+            height: 34px;
+            margin-top: -17px;
+            margin-left: -17px;
+            background-color: #ffffff;
+            background-repeat: no-repeat;
+            background-image: url('/themes/fstec/images/loading.gif');
+            opacity: 1;
+        }
+        .loaded_hiding .preloader {
+            transition: 0.3s opacity;
+            opacity: 0;
+        }
+        .loaded .preloader {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="preloader">
+      <div class="preloader__row">
+        <div class="preloader__item"></div>
+      </div>
+    </div> 
+    <div id="wrap">
+
+    
+        <div class="page-header litegray-gradient">
+            <div class="row inner">
+                <div class="col-md-2 col-lg-2 visible-md visible-lg text-center ">
+                    <a href="http://fstec.ru" target="_blank" rel="noopener noreferrer" title=""><img class="fstec" src="/themes/fstec/css/images/fstec.png" alt='&laquo;ФСТЭК России&raquo;'></a>
+                </div>
+                <div class="col-md-8 col-lg8 text-center">
+                                            <h1>Банк данных угроз безопасности информации</h1>
+                    
+                    <div class="row text-center">
+                        <div class="col-lg-6 text-left visible-md visible-lg">
+                            <h4>Федеральная служба по техническому и экспортному контролю</h4>
+                            <h4><small>ФСТЭК России</small></h4>
+                        </div>
+                        <div class="col-lg-6 text-left visible-md visible-lg">
+                            <h4>Государственный научно-исследовательский испытательный институт проблем технической защиты информации</h4>
+                            <h4><small>ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;</small></h4>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2 col-lg-2 visible-md visible-lg text-center">
+                    <img class="gniii" src="/themes/fstec/css/images/gniii.png" alt='ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;'>
+                </div>
+            </div>
+        </div>
+                <div class="nav-wrapper">
+            <nav id="top-nav" class="navbar navbar-inverse" role="navigation">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#top-menu">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                </div>
+
+                <div class="collapse navbar-collapse" id="top-menu">
+                                        <ul class="nav navbar-nav" id="menu">
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/threat">Угрозы <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/threat">Перечень угроз</a></li>
+<li><a href="/threat-section">Новый раздел угроз</a></li>
+<li><a href="/threat/ai">Угрозы ИИ</a></li>
+</ul>
+</li>
+<li class="dropdown active"><a class="dropdown-toggle" data-toggle="dropdown" href="/vul">Уязвимости <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li class="active"><a href="/vul">Список уязвимостей</a></li>
+<li><a href="/webvulns">Типовые уязвимости веб-приложений</a></li>
+<li><a href="/vul/danger">Наиболее опасные уязвимости</a></li>
+<li><a href="/vul/ai">Уязвимости в ПО для разработки ИИ</a></li>
+<li><a href="/charts">Инфографика</a></li>
+<li><a href="/calc">Калькулятор CVSS V2</a></li>
+<li><a href="/calc3">Калькулятор CVSS V3</a></li>
+<li><a href="/calc31">Калькулятор CVSS V3.1</a></li>
+<li><a href="/calc4">Калькулятор CVSS V4</a></li>
+<li><a href="/scanoval">ScanOVAL</a></li>
+<li><a href="/scanovalforlinux">ScanOVAL для Linux</a></li>
+<li><a href="/software-section/bducpe">Каталог ПО</a></li>
+</ul>
+</li>
+<li title="Результаты тестирования обновлений ПО"><a href="/software-section/updates">Тестирование обновлений</a></li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/documents">Документы <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/terms">Термины</a></li>
+<li><a href="/regulations">Регламент включения уязвимостей</a></li>
+<li><a href="/documents">Все документы</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/contacts/sendmail">Обратная связь<span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/contacts/sendmail">Написать администратору</a></li>
+<li><a href="/contacts/email">Электронная почта</a></li>
+<li><a href="/contacts/vulreport">Сообщить об уязвимости</a></li>
+<li><a href="/contacts/threatreport">Сообщить об угрозе</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/news/summary">Обновления <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/news/summary">Новости сайта</a></li>
+<li><a href="/feed">Список каналов (RSS, Atom)</a></li>
+<li><a target="window" rel="noopener noreferrer" href="https://t.me/bdufstecru">Telegram</a></li>
+<li><a target="window" rel="noopener noreferrer" href="https://max.ru/id3666088317_gos">MAX</a></li>
+</ul>
+</li>
+<li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="/site/partners">Участники <span class="caret"></span></a>
+<ul class="dropdown-menu">
+<li><a href="/partners">Организации</a></li>
+<li><a href="/contacts/vulreport/list">Исследователи</a></li>
+<li><a href="/rating">Рейтинг исследователей</a></li>
+</ul>
+</li>
+<li title="Обучение"><a href="/education">Обучение</a></li>
+<li title="Банк данных угроз АСУ ТП"><a target="_blank" rel="noopener noreferrer" href="https://bduasutp.fstec.ru">БДУ АСУ ТП</a></li>
+<li title="Официальный сайт ФСТЭК России"><a target="_blank" rel="noopener noreferrer" href="http://fstec.ru">ФСТЭК России</a></li>
+</ul>                    
+                                            <div class="row">
+                            <div class="col-xs-12 col-sm-3 col-md-3 pull-right">
+
+                                <form action="/search" class="form-control-static" role="search">
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" placeholder="Поиск" name="q">
+                                        <div class="input-group-btn">
+                                            <button class="btn btn-default" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+                                        </div>
+                                    </div>
+                                </form>
+
+                            </div>
+                        </div>
+                                </nav>
+        </div>
+                <div class="container-fluid">
+
+                            <ol class="breadcrumb">
+<li><a href="/">Главная</a></li><li>Список уязвимостей</li></ol><!-- breadcrumbs -->
+                        <div class="row">
+                    <div class="col-sm-12 col-md-6 col-lg-6 col-md-push-3 col-lg-push-3">
+        
+<!--div class="row">
+    <div class="context-search input-group col-sm-3 col-sm-offset-9" title="Контекстный поиск по названиям уязвимостей">
+        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
+        <input type="text" id="search" name="search" class="form-control input-sm"/>
+    </div>
+</div-->
+
+<!--  -->
+
+<div id="vuls" class="list-view">
+&nbsp;<div class="btn-group"><button class="btn btn-default btn-xs dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">Сортировка: <span class="caret"></span></button><ul class="dropdown-menu" role="menu" id="yw0">
+<li class="active"><a href="/vul?sort=identifier">по идентификатору</a></li>
+<li><a href="/vul?sort=datv">по выявлению</a></li>
+<li><a href="/vul?sort=bsc">по критичности</a></li>
+</ul></div>
+<div class="sizer pull-left btn-toolbar">Выводить по: 10, <a href="/vul?size=20">20</a>, <a href="/vul?size=50">50</a>, <a href="/vul?size=100">100</a></div>
+<div class="summary pull-right hidden-xs">Элементы с 1 по 10 из 84542</div>
+<div class="clearfix"></div><table class="table table-striped table-vuls">
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03438">BDU:2026-03438</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с неограниченным распределением ресурсов. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, вызвать отказ в обслуживании">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с неограниченным распределением ресурсов, позволяющая нарушителю вызвать отказ в обслуживании</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>11.03.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03437">BDU:2026-03437</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с использованием имени с неправильной ссылкой. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, выполнить произвольный код">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с использованием имени с неправильной ссылкой, позволяющая нарушителю выполнить произвольный код</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-middle" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>11.03.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03436">BDU:2026-03436</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с непринятием мер по защите структуры веб-страницы. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, выполнить произвольный код">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с непринятием мер по защите структуры веб-страницы, позволяющая нарушителю выполнить произвольный код</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>11.03.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03435">BDU:2026-03435</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с обходом аутентификации посредством использования альтернативного пути или канала. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, получить несанкционированный доступ к защищаемой информации">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с обходом аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю получить несанкционированный доступ к защищаемой информации</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-middle" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>11.03.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03434">BDU:2026-03434</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab связана с распределением ресурсов без ограничений или регулирования. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, вызвать отказ в обслуживании">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03433">BDU:2026-03433</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с распределением ресурсов без ограничений или регулирования. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, вызвать отказ в обслуживании путем отправки специально сформированных запросов">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с распределением ресурсов без ограничений или регулирования, позволяющая нарушителю вызвать отказ в обслуживании</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03432">BDU:2026-03432</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связана с использованием регулярного выражения с неэффективной вычислительной сложностью. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, вызвать отказ в обслуживании">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связанная с использованием регулярного выражения с неэффективной вычислительной сложностью, позволяющая нарушителю вызвать отказ в обслуживании</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03431">BDU:2026-03431</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость интерфейса Mermaid UI программной платформы на базе git для совместной работы над кодом GitLab связана с недостаточной защитой структуры веб-страницы. Эксплуатация уязвимости может позволить нарушителю, действующему удалённо, выполнить произвольный код">Уязвимость интерфейса Mermaid UI программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю выполнить произвольный код</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-high" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03430">BDU:2026-03430</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab связана с распределением ресурсов без ограничений или регулирования. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, вызвать отказ в обслуживании">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-middle" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+
+<tr >
+    <td class="col-lg-3 col-xs-3">
+        <h4><a class="confirm-vul" href="/vul/2026-03429">BDU:2026-03429</a></h4>
+    </td>
+    <td class="col-lg-8 col-xs-9">
+        <div class="name">
+            <h5 data-content="Уязвимость программной платформы на базе git для совместной работы над кодом GitLab Enterprise Edition (EE) связана с обходом процедуры аутентификации посредством использования альтернативного пути или канала. Эксплуатация уязвимости может позволить нарушителю, действующему удаленно, обойти существующие механизмы безопасности">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab Enterprise Edition (EE), связанная с обходом процедуры аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю обойти существующие механизмы безопасности</h5>
+        </div>
+<!--        <div class="soft">-->
+<!--            --><!--        </div>-->
+    </td>
+    <td class="col-lg-1">
+		<div class="td-inner text-center">
+			<div class="bsc bsc-middle" data-toggle="popover" data-content='<span class="label label-low">Низкий уровень опасности</span><br><span class="label label-middle">Средний уровень опасности</span><br><span class="label label-high">Высокий уровень опасности</span><br><span class="label label-critical">Критический уровень опасности</span>'></div>		
+			<span class="d-table hidden-xs"><span>25.02.2026</span></span>
+		</div>
+    </td>
+</tr>
+</table>
+<div class="link-pager"><ul class="pagination pagination-sm" id="yw1"><li class="first disabled"><a href="/vul"><<</a></li>
+<li class="previous disabled"><a href="/vul"><</a></li>
+<li class="page active"><a href="/vul">1</a></li>
+<li class="page"><a href="/vul?page=2">2</a></li>
+<li class="page"><a href="/vul?page=3">3</a></li>
+<li class="page"><a href="/vul?page=4">4</a></li>
+<li class="page"><a href="/vul?page=5">5</a></li>
+<li class="page"><a href="/vul?page=6">6</a></li>
+<li class="page"><a href="/vul?page=7">7</a></li>
+<li class="page"><a href="/vul?page=8">8</a></li>
+<li class="page"><a href="/vul?page=9">9</a></li>
+<li class="page"><a href="/vul?page=10">10</a></li>
+<li class="next"><a href="/vul?page=2">></a></li>
+<li class="last"><a href="/vul?page=8455">>></a></li></ul></div><div class="keys" style="display:none" title="/vul"><span>95310</span><span>95335</span><span>95333</span><span>95323</span><span>95441</span><span>95440</span><span>95439</span><span>95438</span><span>95437</span><span>95442</span></div>
+</div>
+            <div class="row">
+            <div class="col-sm-12 text-center">
+                                <p><a href="/files/documents/vullist.xlsx">Скачать сведения об уязвимостях в формате XLSX</a></p>
+            </div>
+        </div>
+    
+    
+    <div class="row">
+        <div class="col-sm-12 text-center">
+                                            <p><a href="/files/documents/vulxml.zip">Скачать сведения об уязвимостях в формате XML</a></p>
+        </div>
+    </div>
+
+        </div><!-- content -->
+    <div class="col-sm-12 col-md-3 col-lg-3 col-md-pull-6 col-lg-pull-6">
+        <div class="portlet" id="yw2">
+<div class="portlet-decoration">
+<div class="portlet-left-decoration-inner">
+<div class="portlet-title">Фильтрация</div>
+</div>
+</div>
+<div class="portlet-content">
+<form role="form" id="vul-filter-form" action="/vul" method="post">
+<input type="hidden" value="ZVFrWVh4MnJxR1Fhfl9vc1J6TEEyNk4xaEplbDlyU3jK2Hxs0DdvkNmsyepmVc2BgVYQHlokUoNY0adwOpG2KQ==" name="YII_CSRF_TOKEN" /><div class="form-group">
+    <label for="search">Контекстный поиск по названию уязвимости</label>
+    <div class="context-search input-group" title="">
+        <!--Далее с фиксом input-group-addon для chrome-->
+        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span><input type="text"
+                                                                                                      id="search"
+                                                                                                      name="search"
+                                                                                                      class="form-control input-sm"
+                                                                                                      placeholder="Введите слово или словосочетание"
+                                                                                                      value=""/>
+    </div>
+</div>
+
+
+<div id="vul-filter-form_es_" class="errorSummary" style="display:none"><p>Необходимо исправить следующие ошибки:</p>
+<ul><li>dummy</li></ul></div><div class="form-group">
+    <label for="VulFilterForm_vendor">Производитель ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                         data-toggle="popover"
+                                                         data-content="Компания (организация) - производитель (разработчик) программного обеспечения в котором обнаружена уязвимость"></span>
+    <input name="VulFilterForm[vendor]" id="VulFilterForm_vendor" type="hidden" />    <div class="errorMessage" id="VulFilterForm_vendor_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_softType">Тип ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                           data-toggle="popover"
+                                                           data-content="Тип программного обеспечения, в котором обнаружена уязвимость"></span>
+    <select name="VulFilterForm[softType]" id="VulFilterForm_softType">
+<option value=""></option>
+<option value="1">Операционная система</option>
+<option value="2">СУБД</option>
+<option value="3">Средство защиты</option>
+<option value="8">&nbsp;&nbsp;Программное средство защиты</option>
+<option value="9">&nbsp;&nbsp;ПО программно-аппаратных средств защиты</option>
+<option value="4">Сетевое средство</option>
+<option value="10">&nbsp;&nbsp;Сетевое программное средство</option>
+<option value="11">&nbsp;&nbsp;ПО сетевого программно-аппаратного средства</option>
+<option value="5">Прикладное ПО информационных систем</option>
+<option value="6">Средство АСУ ТП</option>
+<option value="12">&nbsp;&nbsp;Программное средство АСУ ТП</option>
+<option value="13">&nbsp;&nbsp;ПО программно-аппаратного средства АСУ ТП</option>
+<option value="7">ПО виртуализации/ПО виртуального программно-аппаратного средства</option>
+<option value="15">Микропрограммный код аппаратных компонент компьютера</option>
+<option value="16">Микропрограммный код</option>
+<option value="19">ПО программно-аппаратного средства</option>
+<option value="20">ПО для разработки ИИ</option>
+<option value="unknown">"Не определен"</option>
+</select>    <div class="errorMessage" id="VulFilterForm_softType_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_soft">Программное обеспечение</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                       data-toggle="popover"
+                                                       data-content="Наименование программного обеспечения, в котором обнаружена уязвимость"></span>
+        <input name="VulFilterForm[soft]" id="VulFilterForm_soft" type="hidden" />    <div class="errorMessage" id="VulFilterForm_soft_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_platf">Аппаратная платформа</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                        data-toggle="popover"
+                                                        data-content="Аппаратная платформа, при установке на которой программное обеспечение содержит уязвимость"></span>
+    <select name="VulFilterForm[platf]" id="VulFilterForm_platf">
+<option value=""></option>
+<option value="-1">Не указана</option>
+<option value="1">x86 (x32 / IA-32)</option>
+<option value="2">64-bit</option>
+<option value="3">SPARCv8</option>
+<option value="5">ESA/390</option>
+<option value="6">z/Architecture</option>
+<option value="7">PowerPC</option>
+<option value="9">Alpha</option>
+<option value="10">IA-64 (Itanium)</option>
+<option value="12">MIPS</option>
+<option value="13">MIPS32</option>
+<option value="14">32-bit</option>
+<option value="16">Supervisor Engine</option>
+<option value="17">MIPS64</option>
+<option value="18">CPU 1211C</option>
+<option value="19">ARM</option>
+<option value="20">iPhone</option>
+<option value="21">iPad</option>
+<option value="22">VMWare vSphere</option>
+<option value="23">SPARC</option>
+<option value="24">s390</option>
+<option value="25">ARM7</option>
+<option value="26">ARM64</option>
+<option value="27">zSeries</option>
+<option value="28">AS/400</option>
+<option value="29">eServer iSeries</option>
+<option value="30">System i</option>
+<option value="31">System Z</option>
+<option value="32">платформа уточняется</option>
+<option value="33">Power</option>
+<option value="34">PA-RISC (64-bit)</option>
+<option value="35">ROMP</option>
+<option value="36">PS/2</option>
+<option value="37">System/370</option>
+<option value="38">iPod</option>
+<option value="39">IA-32</option>
+<option value="40">DEC Alpha</option>
+<option value="41">AVR32</option>
+<option value="42">Itanium</option>
+<option value="43">PA-RISC</option>
+<option value="44">68k</option>
+<option value="45">SH3</option>
+<option value="46">VAX</option>
+<option value="47">SPARC64</option>
+<option value="48">ARMel</option>
+<option value="49">ARMhf</option>
+<option value="50">MIPSel</option>
+<option value="51">s390x</option>
+<option value="52">Power Architecture</option>
+<option value="53">Cisco ISE</option>
+<option value="57">Nexus 7</option>
+<option value="58">Nexus</option>
+<option value="59">Android One</option>
+<option value="60">Nexus 5X</option>
+<option value="61">Nexus 9</option>
+<option value="63">Nexus 6P</option>
+<option value="64">Pixel C</option>
+<option value="65">Nexus 6</option>
+<option value="66">Nexus 5</option>
+<option value="67">Cisco ASA 5500 Series Adaptive Security Appliances</option>
+<option value="68">Cisco ASA 5500-X Series Next-Generation Firewalls</option>
+<option value="69">Cisco ASA Services Module for Cisco Catalyst 6500 Series Switches and Cisco 7600 Series Routers</option>
+<option value="70">Cisco ASA 1000V Cloud Firewall</option>
+<option value="71">Cisco Adaptive Security Virtual Appliance (ASAv)</option>
+<option value="72">Cisco Firepower 4100 Series</option>
+<option value="73">Cisco Firepower 9300 ASA Security Module</option>
+<option value="74">Cisco Firepower Threat Defense Software</option>
+<option value="75">Cisco Firewall Services Module</option>
+<option value="76">Cisco Industrial Security Appliance 3000</option>
+<option value="77">Cisco PIX Firewalls</option>
+<option value="80">ARM32</option>
+<option value="84">IBM</option>
+<option value="85">Nexus Player</option>
+<option value="86">Pixel XL</option>
+<option value="87">Plxel</option>
+<option value="88">Android</option>
+<option value="89">Nexus 10</option>
+<option value="90">Exynos AP</option>
+<option value="91">Intel NUC 6-gen</option>
+<option value="92">Zaurus</option>
+<option value="93">Motorola 68k</option>
+<option value="94">Linux</option>
+<option value="95">SRX 210</option>
+<option value="96">SRX 240</option>
+<option value="97">SRX 650</option>
+<option value="98">SSG-5</option>
+<option value="99">SSG-20</option>
+<option value="100">MP70</option>
+<option value="101">oMG500</option>
+<option value="102">oMG2000</option>
+<option value="103">MG90</option>
+<option value="104">FX30</option>
+<option value="105">WP76xx</option>
+<option value="106">WP85xx</option>
+<option value="107">UAP-AC-Lite/LR/Pro/EDU/M/M-PRO/IW/IW-Pro</option>
+<option value="108">UAP-AC-HD/SHD</option>
+<option value="109">UAP-LR</option>
+<option value="110">UAP-OD</option>
+<option value="111">UAP-OD5</option>
+<option value="112">UAP-v2</option>
+<option value="113">UAP-LR-v2</option>
+<option value="114">UAP-IW</option>
+<option value="115">UAP-Pro</option>
+<option value="117">US-L2-POE</option>
+<option value="118">US-16-XG</option>
+<option value="119">Itanium-Based</option>
+<option value="120">Cisco ASR 1000</option>
+<option value="121">Cisco cBR-8</option>
+<option value="122">Cisco 5760 WLC</option>
+<option value="123">Cisco Catalyst 4500E Supervisor Engine 8-E</option>
+<option value="124">Cisco NGWC 3850</option>
+<option value="126">MediaTek M-ALPS03353876</option>
+<option value="127">MediaTek M-ALPS03353861</option>
+<option value="128">MediaTek M-ALPS03353869</option>
+<option value="129">MediaTek M-ALPS03353867</option>
+<option value="130">MediaTek M-ALPS03353872</option>
+<option value="131">Broadcom B-V2017063001</option>
+<option value="132">Broadcom BCM4355C0 9.44.78.27.0.1.56</option>
+<option value="133">Broadcom BCM4355C0 9.44.78.27.0.1.57</option>
+<option value="134">Avaya Fabric Connect Virtual Services Platform 8000</option>
+<option value="135">Avaya Fabric Connect Virtual Services Platform7200</option>
+<option value="136">Avaya Fabric Connect Virtual Services Platform 4000</option>
+<option value="137">Cisco ASR 5000</option>
+<option value="138">Cisco ASR 5500</option>
+<option value="139">Cisco ASR 5700</option>
+<option value="144">Sierra Wireless AirLink GX 440</option>
+<option value="146">Multilayer Director Switches</option>
+<option value="147">Nexus 2000 Series Fabric Extenders</option>
+<option value="148">Nexus 3000 Series Switches</option>
+<option value="150">Nexus 3500 Platform Switches</option>
+<option value="151">Nexus 5000 Series Switches</option>
+<option value="152">Nexus 5500 Platform Switches</option>
+<option value="153">Nexus 5600 Platform Switches</option>
+<option value="154">Nexus 6000 Series Switches</option>
+<option value="155">Nexus 7000 Series Switches</option>
+<option value="156">Nexus 7700 Series Switches</option>
+<option value="157">Nexus 9000 Series Switches - Standalone, NX-OS mode</option>
+<option value="158">Nexus 9500 R-Series Line Cards and Fabric Modules</option>
+<option value="160">Nexus 9500 R-Series Line Cards</option>
+<option value="161">Nexus 9500 R-Series Fabric Modules</option>
+<option value="162">Nexus 9000 Series Switches</option>
+<option value="163">Dell EMC XtremIO</option>
+<option value="164">Dell EMC VMAX</option>
+<option value="165">Dell EMC Unity</option>
+<option value="166">Dell EMC VPLEX</option>
+<option value="167">Firepower 4100 Series Next-Generation Firewall</option>
+<option value="168">Firepower 9300 Security Appliance</option>
+<option value="170">S820A</option>
+<option value="171">MDM6600</option>
+<option value="172">MDM9206</option>
+<option value="173">MDM9310</option>
+<option value="174">MDM9607</option>
+<option value="175">MDM9615</option>
+<option value="176">MDM9625</option>
+<option value="177">MDM9635M</option>
+<option value="178">MDM9640</option>
+<option value="179">MDM9645</option>
+<option value="180">MDM9650</option>
+<option value="181">MDM9655</option>
+<option value="182">MSM8909W</option>
+<option value="183">S820AM</option>
+<option value="184">QSC6270</option>
+<option value="185">S600</option>
+<option value="186">SD 200</option>
+<option value="187">SD 210</option>
+<option value="188">SD 212</option>
+<option value="189">SD 205</option>
+<option value="190">SD 400</option>
+<option value="191">SD 410</option>
+<option value="192">SD 412</option>
+<option value="193">SD 425</option>
+<option value="194">SD 430</option>
+<option value="195">SD 615</option>
+<option value="196">SD 616</option>
+<option value="197">SD 415</option>
+<option value="198">SD 617</option>
+<option value="199">SD 625</option>
+<option value="200">SD 650</option>
+<option value="201">SD 652</option>
+<option value="202">SD 800</option>
+<option value="203">SD 808</option>
+<option value="204">Cisco 3000 Series Industrial Security Appliances (ISAs)</option>
+<option value="205">SD 820</option>
+<option value="206">SD 835</option>
+<option value="207">SDX20M</option>
+<option value="208">SD 600</option>
+<option value="209">SD 602A</option>
+<option value="210">SDX20</option>
+<option value="211">SD 810</option>
+<option value="212">SD 450</option>
+<option value="213">SD 845</option>
+<option value="214">MDM9207</option>
+<option value="215">APQ8096AU</option>
+<option value="216">MSM8996AU</option>
+<option value="217">SD 850</option>
+<option value="218">MDM0296</option>
+<option value="220">SD 820A</option>
+<option value="221">SDX 20</option>
+<option value="222">MDM9649</option>
+<option value="223">IPQ4019</option>
+<option value="224">QCA4531</option>
+<option value="225">QCA6174A</option>
+<option value="226">QCA6574AU</option>
+<option value="227">QCA6584</option>
+<option value="228">QCA6584AU</option>
+<option value="229">QCA9377</option>
+<option value="230">QCA9378</option>
+<option value="231">QCA9379</option>
+<option value="232">SD 427</option>
+<option value="233">SD 435</option>
+<option value="234">SDM630</option>
+<option value="235">SDM636</option>
+<option value="236">SDM660</option>
+<option value="237">FSM9055</option>
+<option value="238">MSM8976</option>
+<option value="239">MSM8937</option>
+<option value="240">SDM845</option>
+<option value="241">MSM8952</option>
+<option value="242">IPQ8064</option>
+<option value="243">QCA9980</option>
+<option value="244">QCA9558</option>
+<option value="245">QCA9880</option>
+<option value="246">QCA9886</option>
+<option value="247">QCA9990</option>
+<option value="248">Cisco Firepower 2100 Series Security Appliances</option>
+<option value="249">Cisco Firepower 4100 Series Security Appliances</option>
+<option value="250">Cisco FTD Virtual (FTDv)</option>
+<option value="251">MDM8996</option>
+<option value="252">MSM8996</option>
+<option value="253">MSM8998</option>
+<option value="254">Canon LBP7750C</option>
+<option value="255">Canon LBP3370</option>
+<option value="256">Canon LBP3460</option>
+<option value="257">Canon LBP6650</option>
+<option value="259">FortiGate-60E-LENC</option>
+<option value="260">Cisco Nexus 5500 Series Switches</option>
+<option value="261">Cisco Nexus 5600 Series Switches</option>
+<option value="262">Cisco Nexus 6000 Series Switches</option>
+<option value="268">vSRX Series</option>
+<option value="270">Cisco ASR 9000 Series Aggregation Services Routers</option>
+<option value="271">Cisco ASR 9922 Router</option>
+<option value="272">Cisco ASR 9010 Router</option>
+<option value="273">Cisco ASR 9904 Router</option>
+<option value="274">Cisco ASR 9006 Router</option>
+<option value="275">Cisco ASR 9001 Router</option>
+<option value="276">Cisco ASR 9912 Router</option>
+<option value="277">SDA660</option>
+<option value="278">Nexus 3000</option>
+<option value="279">Nexus 9000</option>
+<option value="280">Nexus 2000</option>
+<option value="281">Nexus 5500</option>
+<option value="282">Nexus 5600</option>
+<option value="283">Nexus 6000</option>
+<option value="284">Nexus 3600</option>
+<option value="285">Nexus 9500 R-Series</option>
+<option value="286">Nexus 3500</option>
+<option value="287">UCS 6100</option>
+<option value="288">UCS 6200</option>
+<option value="289">UCS 6300</option>
+<option value="290">CC2642R</option>
+<option value="291">CC2640R2</option>
+<option value="292">CC2640</option>
+<option value="293">CC2650</option>
+<option value="294">CC2540</option>
+<option value="295">CC2541</option>
+<option value="297">CC2640R2F</option>
+<option value="298">CC1350</option>
+<option value="300">Cisco Aironet 1810</option>
+<option value="304">Cisco Aironet 4800</option>
+<option value="311">SD 710</option>
+<option value="312">SDM439</option>
+<option value="313">SD 429</option>
+<option value="314">SD 439</option>
+<option value="315">SD 670</option>
+<option value="316">SXR1130</option>
+<option value="317">SD 636</option>
+<option value="318">SD 712</option>
+<option value="319">Snapdragon High Med 2016</option>
+<option value="320">SDX24</option>
+<option value="321">SD 632</option>
+<option value="325">Adaptive Security Appliance (ASA) 5500-X Series with FirePOWER Services</option>
+<option value="326">Adaptive Security Appliance (ASA) 5500-X Series Next-Generation Firewalls</option>
+<option value="327">Advanced Malware Protection (AMP) for Networks, 7000 Series Appliances</option>
+<option value="328">Advanced Malware Protection (AMP) for Networks, 8000 Series Appliances</option>
+<option value="329">Firepower 2100 Series Security Appliances</option>
+<option value="330">Firepower 4100 Series Security Appliances</option>
+<option value="331">FirePOWER 7000 Series Appliances</option>
+<option value="332">FirePOWER 8000 Series Appliances</option>
+<option value="333">Firepower 9300 Series Security Appliances</option>
+<option value="334">FirePOWER Threat Defense for Integrated Services Routers (ISRs)</option>
+<option value="335">Firepower Threat Defense Virtual</option>
+<option value="336">Industrial Ethernet 3000 Series Switches</option>
+<option value="337">Next-Generation Intrusion Prevention System (NGIPSv)</option>
+<option value="338">Virtual Next-Generation Intrusion Prevention System (NGIPSv)</option>
+<option value="339">Cisco 3000 Series Industrial Security Appliances (ISA)</option>
+<option value="340">ASA 5500-X Series Next-Generation Firewalls</option>
+<option value="341">ASA Services Module for Cisco Catalyst 6500 Series Switches and Cisco 7600 Series Routers</option>
+<option value="342">Adaptive Security Virtual Appliance (ASAv)</option>
+<option value="343">Firepower 9300 ASA Security Module</option>
+<option value="344">FTD Virtual (FTDv)</option>
+<option value="346">Cisco Firepower Threat Defense Virtual (FTDv)</option>
+<option value="347">МФК1500</option>
+<option value="348">МФК3000</option>
+<option value="349">Catalyst 3560X-48T-E Switch</option>
+<option value="350">Catalyst 2960C-8TC-S Switch</option>
+<option value="351">Catalyst 3560X-48P-S Switch</option>
+<option value="352">Catalyst 2960X-48LPS-L Switch</option>
+<option value="353">Catalyst 3560X-48U-S Switch</option>
+<option value="354">Catalyst 3560CG-8TC-S Compact Switch</option>
+<option value="355">Catalyst 2960X-24PS-L Switch</option>
+<option value="356">Embedded Service 2020 CON B Switch</option>
+<option value="357">Catalyst 2960X-24PD-L Switch</option>
+<option value="359">ARM926EJ</option>
+<option value="360">MGE Galaxy 3000</option>
+<option value="361">MGE Galaxy 4000</option>
+<option value="362">MGE Galaxy 5000</option>
+<option value="363">MGE Galaxy 6000</option>
+<option value="364">MGE Galaxy 9000</option>
+<option value="365">MGE EPS 6000</option>
+<option value="366">MGE EPS 7000</option>
+<option value="367">MGE EPS 8000</option>
+<option value="368">MGE Comet UPS</option>
+<option value="370">STS MGE Upsilon</option>
+<option value="371">Cisco FirePOWER Appliance 7050</option>
+<option value="372">Cisco FirePOWER Appliance 8360</option>
+<option value="373">Cisco Firepower Management Center 2500</option>
+<option value="374">Cisco FirePOWER Appliance 8120</option>
+<option value="375">Cisco FirePOWER Appliance 8260</option>
+<option value="376">Cisco AMP 8150</option>
+<option value="377">Cisco FirePOWER Appliance 8350</option>
+<option value="378">Cisco FirePOWER Appliance 8130</option>
+<option value="379">Cisco AMP 7150</option>
+<option value="380">Cisco FirePOWER Appliance 8140</option>
+<option value="381">Cisco FirePOWER Appliance 8270</option>
+<option value="382">Cisco FirePOWER Appliance 8390</option>
+<option value="383">Cisco NGIPS Virtual Appliance</option>
+<option value="384">Cisco Firepower Management Center 4500</option>
+<option value="385">Cisco FirePOWER Appliance 8250</option>
+<option value="386">Cisco FirePOWER Appliance 7010</option>
+<option value="387">Cisco FirePOWER Appliance 7120</option>
+<option value="388">Cisco FireSIGHT Management Center 750</option>
+<option value="389">Cisco FirePOWER Appliance 8370</option>
+<option value="390">Cisco Firepower Management Center 4000</option>
+<option value="391">Cisco FireSIGHT Management Center 3500</option>
+<option value="392">Cisco FirePOWER Appliance 8290</option>
+<option value="393">Cisco FirePOWER Appliance 7125</option>
+<option value="394">Cisco FireSIGHT Management Center 1500</option>
+<option value="395">Cisco Firepower Management Center 1000</option>
+<option value="396">Cisco FirePOWER Appliance 7020</option>
+<option value="397">Cisco FirePOWER Appliance 7110</option>
+<option value="399">Cisco FirePOWER Appliance 7115</option>
+<option value="400">Cisco Firepower Management Center 2000</option>
+<option value="402">Cisco FirePOWER Appliance 7030</option>
+<option value="403">EX2300</option>
+<option value="404">EX3400</option>
+<option value="405">EX4600</option>
+<option value="406">QFX3K</option>
+<option value="407">QFX5K</option>
+<option value="408">QFX5200</option>
+<option value="409">QFX5110</option>
+<option value="410">SRX</option>
+<option value="411">EX2200/VC</option>
+<option value="412">EX3300/VC</option>
+<option value="413">EX4550/VC</option>
+<option value="414">EX3200</option>
+<option value="415">EX4200</option>
+<option value="416">EX4300</option>
+<option value="417">EX6200</option>
+<option value="419">QFX3600</option>
+<option value="420">QFX3500</option>
+<option value="421">QFX5100</option>
+<option value="422">NFX150</option>
+<option value="423">NFX250</option>
+<option value="424">QFX10000 Series</option>
+<option value="425">Orange Livebox ARV7519RW22</option>
+<option value="426">TelePresence Multipoint Control Unit 5300 Series</option>
+<option value="427">TelePresence Multipoint Control Unit MSE 8510</option>
+<option value="428">TelePresence Multipoint Control Unit MSE 8420</option>
+<option value="429">TelePresence Server 7010</option>
+<option value="430">TelePresence Server MSE 8710</option>
+<option value="431">TelePresence Server on Multiparty Media 310</option>
+<option value="432">TelePresence Server on Multiparty Media 320</option>
+<option value="433">TelePresence Server on Multiparty Media 820</option>
+<option value="434">Secutech RiS-11</option>
+<option value="435">Secutech RiS-22</option>
+<option value="436">Secutech RiS-33</option>
+<option value="437">IP Conference Phone 7832</option>
+<option value="438">IP Conference Phone 8832</option>
+<option value="439">IP Phone 7811</option>
+<option value="440">IP Phone 7821</option>
+<option value="441">IP Phone 7841</option>
+<option value="442">IP Phone 7861</option>
+<option value="443">IP Phone 8800 Series</option>
+<option value="444">IP Phone 8800 Series with Multiplatform Firmware</option>
+<option value="445">IP Phone 8800 Series - VPN feature</option>
+<option value="446">IP Phone 8861</option>
+<option value="447">IP Phone 8865 with Multiplatform Firmware</option>
+<option value="448">IP Phone 8865</option>
+<option value="449">Unified IP Conference Phone 8831</option>
+<option value="450">Unified IP Conference Phone 8831 for Third-Party Call Control</option>
+<option value="451">Wireless IP Phone 8821</option>
+<option value="452">SPA112 Series IP Phones</option>
+<option value="453">SPA525 Series IP Phones</option>
+<option value="454">SPA5X5 Series IP Phones</option>
+<option value="455">Siemens SIMATIC S7-400</option>
+<option value="456">Siemens SIMATIC S7-400 PN/DP</option>
+<option value="457">Siemens SIMATIC S7-400H</option>
+<option value="458">Siemens SIMATIC S7-410</option>
+<option value="459">Network Convergence System 1000 Series</option>
+<option value="460">Intel Core</option>
+<option value="461">Intel Xeon</option>
+<option value="462">Cisco Nexus 3000 Series Fabric Switches</option>
+<option value="463">Cisco Nexus 3500 Series Fabric Switches</option>
+<option value="464">Cisco Nexus 9000 Series Fabric Switches</option>
+<option value="465">Cisco Nexus 9000</option>
+<option value="466">Cisco Firepower 4100</option>
+<option value="467">Cisco Firepower 9300</option>
+<option value="468">Cisco MDS 9000</option>
+<option value="469">Cisco Nexus 3000</option>
+<option value="470">Cisco Nexus 3500</option>
+<option value="471">Cisco Nexus 7000</option>
+<option value="472">Cisco Nexus 7700</option>
+<option value="474">Cisco UCS 6200</option>
+<option value="475">Cisco UCS 6300</option>
+<option value="476">Cisco MDS 9000 Series Multilayer Switches</option>
+<option value="477">Cisco Nexus 3000 Series Switches</option>
+<option value="478">Cisco Nexus 3500 Platform Switches</option>
+<option value="479">Cisco Nexus 3600 Platform Switches</option>
+<option value="480">Cisco Nexus 7000 Series Switches</option>
+<option value="481">Cisco Nexus 7700 Series Switches</option>
+<option value="482">Cisco Nexus 9000 Series Switches</option>
+<option value="483">Cisco Nexus 9500 R-Series Line Cards and Fabric Modules</option>
+<option value="484">Cisco Nexus 9500 R-Series Line Cards</option>
+<option value="485">Cisco Firepower 4100 Series Next-Generation Firewalls</option>
+<option value="486">Cisco Firepower 9300 Security Appliance</option>
+<option value="487">Cisco Nexus 2000 Series Fabric Extenders</option>
+<option value="488">Cisco Nexus 5500 Platform Switches</option>
+<option value="489">Cisco Nexus 5600 Platform Switches</option>
+<option value="491">Cisco Nexus 1000V</option>
+<option value="492">Cisco Nexus 3600</option>
+<option value="493">Cisco Nexus 5500</option>
+<option value="494">Cisco Nexus 5600</option>
+<option value="495">Cisco Nexus 6000</option>
+<option value="496">Cisco Nexus 9500</option>
+<option value="497">Cisco UCS 6400</option>
+<option value="499">Cisco Nexus 2000</option>
+<option value="500">DIR-823G</option>
+<option value="501">Dasan GPON</option>
+<option value="502">Cisco IP Phone 8800</option>
+<option value="503">Cisco IP Conference Phone 8832</option>
+<option value="504">Cisco IP Phone 8821</option>
+<option value="505">Cisco IP Phone 8821-EX</option>
+<option value="507">Cisco IP Phone 7800</option>
+<option value="508">Cisco IP Conference Phone 8831</option>
+<option value="509">Cisco Catalyst 6500</option>
+<option value="510">Small Business SPA514G IP Phones</option>
+<option value="511">Cisco ASR 9000</option>
+<option value="512">Cisco Aironet 1540 Series APs</option>
+<option value="513">Cisco Aironet 1560 Series APs</option>
+<option value="514">Cisco Aironet 1800 Series APs</option>
+<option value="515">Cisco Aironet 2800 Series APs</option>
+<option value="516">Cisco Aironet 3800 Series APs</option>
+<option value="517">QFX 5000 series</option>
+<option value="518">SRX5000 Series</option>
+<option value="519">SRX Series</option>
+<option value="520">NFX Series</option>
+<option value="521">ACX Series</option>
+<option value="522">QFX10K Series</option>
+<option value="523">EX series</option>
+<option value="524">QFX series</option>
+<option value="525">QFX5200 Series</option>
+<option value="526">QFX5110 Series</option>
+<option value="527">EX3400 Series</option>
+<option value="528">EX2300 Series</option>
+<option value="529">Yealink SIP-T21P E2</option>
+<option value="530">Cisco Firepower 2100 Series</option>
+<option value="531">Cisco ASA 5500 Series</option>
+<option value="532">Cisco ASA 5500-X Series</option>
+<option value="533">Cisco ASA Services Module for Cisco Catalyst 6500 Series</option>
+<option value="534">Cisco ASA Services Module for Cisco 7600 Series</option>
+<option value="535">Cisco Web Security Appliance</option>
+<option value="536">Cisco ASA 5505 Series</option>
+<option value="537">Cisco ASA 5500-X Series with FirePOWER Services</option>
+<option value="538">Cisco Advanced Malware Protection for Networks for FirePOWER 7000 Series</option>
+<option value="539">Cisco AMP for Networks for FirePOWER 8000 Series</option>
+<option value="541">Cisco Firepower 8000 Series</option>
+<option value="542">Cisco Small Business 200 Series</option>
+<option value="543">Cisco Small Business 300 Series</option>
+<option value="544">Cisco Small Business 500 Series</option>
+<option value="545">Cisco 250 Series</option>
+<option value="546">Cisco 350 Series</option>
+<option value="547">Cisco 350X Series</option>
+<option value="548">Cisco 550X Series</option>
+<option value="549">Cisco Catalyst 7600 Series</option>
+<option value="550">Intel Broadwell U i5 vPro</option>
+<option value="551">8th Generation Intel Core Processor</option>
+<option value="552">7th Generation Intel Core Processor</option>
+<option value="553">Juniper EX4300-MP Series</option>
+<option value="554">Juniper SRX340 Series</option>
+<option value="555">Juniper SRX345 Series</option>
+<option value="556">Juniper SRX Series</option>
+<option value="558">Cisco Aironet 1560</option>
+<option value="559">Cisco Aironet 1800</option>
+<option value="560">Cisco Aironet 2800</option>
+<option value="561">Cisco Aironet 3800</option>
+<option value="562">Cisco Aironet 1540</option>
+<option value="563">Cisco 3000 Series Industrial Security Appliances</option>
+<option value="564">Cisco ASR 9000v</option>
+<option value="565">Cisco ASR 9001</option>
+<option value="566">Cisco ASR 9006</option>
+<option value="567">Cisco ASR 9010</option>
+<option value="568">Cisco ASR 9901</option>
+<option value="569">Cisco ASR 9904</option>
+<option value="570">Cisco ASR 9906</option>
+<option value="571">Cisco ASR 9910</option>
+<option value="572">Cisco ASR 9912</option>
+<option value="573">Cisco ASR 9922</option>
+<option value="574">Cisco RV320</option>
+<option value="575">Cisco RV325</option>
+<option value="576">Catalyst WS-C2960L-8TS-LL</option>
+<option value="577">Catalyst WS-C2960L-8PS-LL</option>
+<option value="578">Catalyst WS-C2960L-16TS-LL</option>
+<option value="579">Catalyst WS-C2960L-16PS-LL</option>
+<option value="580">Catalyst WS-C2960L-24TS-LL</option>
+<option value="581">Catalyst WS-C2960L-24PS-LL</option>
+<option value="582">Catalyst WS-C2960L-48TS-LL</option>
+<option value="583">Catalyst WS-C2960L-48PS-LL</option>
+<option value="584">Catalyst WS-C2960L-24TQ-LL</option>
+<option value="585">Catalyst WS-C2960L-24PQ-LL</option>
+<option value="586">Catalyst WS-C2960L-48TQ-LL</option>
+<option value="587">Catalyst WS-C2960L-48PQ-LL</option>
+<option value="588">Catalyst WS-C2960L-SM-8TS</option>
+<option value="589">Catalyst WS-C2960L-SM-8PS</option>
+<option value="590">Catalyst WS-C2960L-SM-16TS</option>
+<option value="591">Catalyst WS-C2960L-SM-16PS</option>
+<option value="592">Catalyst WS-C2960L-SM-24TS</option>
+<option value="593">Catalyst WS-C2960L-SM-24PS</option>
+<option value="594">Catalyst WS-C2960L-SM-48TS</option>
+<option value="595">Catalyst WS-C2960L-SM-48PS</option>
+<option value="596">Catalyst WS-C2960L-SM-24TQ</option>
+<option value="597">Catalyst WS-C2960L-SM-24PQ</option>
+<option value="598">Catalyst WS-C2960L-SM-48TQ</option>
+<option value="599">Catalyst WS-C2960L-SM-48PQ</option>
+<option value="600">Catalyst C2960L-DNA-E-8</option>
+<option value="601">Catalyst C2960L-DNA-E-16</option>
+<option value="602">Catalyst C2960L-DNA-E-24</option>
+<option value="603">Catalyst C2960L-DNA-E-48</option>
+<option value="604">Catalyst Digital Building CDB-8U</option>
+<option value="605">Catalyst Digital Building CDB-8P</option>
+<option value="606">UCS B22 M3 Blade Server</option>
+<option value="607">UCS B200 M2 Blade Server</option>
+<option value="608">UCS B200 M3 Blade Server</option>
+<option value="609">UCS B200 M4 Blade Server</option>
+<option value="610">UCS B200 M5 Blade Server</option>
+<option value="611">UCS B230 M2 Blade Server</option>
+<option value="612">UCS B250 M2 Extended Memory Blade Server</option>
+<option value="613">UCS B260 M4 Blade Server</option>
+<option value="614">UCS B420 M3 Blade Server</option>
+<option value="615">UCS B420 M4 Blade Server</option>
+<option value="616">UCS B440 M2 High-Performance Blade Server</option>
+<option value="617">UCS B460 M4 Blade Server</option>
+<option value="618">UCS B480 M5 Blade Server</option>
+<option value="619">Cisco MDS 9000 Series</option>
+<option value="620">Cisco Nexus 1000V Switch for Microsoft Hyper-V</option>
+<option value="621">Cisco Nexus 1000V Switch for VMware vSphere</option>
+<option value="622">Cisco Nexus 3000 Series</option>
+<option value="624">Cisco Nexus 9000 Series Switches in standalone NX-OS mode</option>
+<option value="628">Cisco Nexus 9000 Series Fabric Switches in ACI mode</option>
+<option value="629">Cisco Nexus 9500 R-Series Switching Platform</option>
+<option value="630">Cisco ASR 9000 Series</option>
+<option value="631">Cisco Nexus 7000 Series</option>
+<option value="632">Cisco Nexus 7700 Series</option>
+<option value="633">Cisco MDS 9700 Series Multilayer Directors</option>
+<option value="634">Cisco Nexus 3600 Platform</option>
+<option value="635">Cisco Nexus 9000 Series</option>
+<option value="636">Cisco Nexus 9500 R-Series</option>
+<option value="637">Cisco Nexus 3500 Series</option>
+<option value="638">Cisco Nexus 3600 Series</option>
+<option value="639">Cisco Nexus 9500 Series</option>
+<option value="640">Nexus 3500 Platform</option>
+<option value="641">Nexus 3000 Series</option>
+<option value="642">Nexus 9500 R-Series Switching Platform</option>
+<option value="643">Nexus 7000 Series</option>
+<option value="644">Nexus 7700 Series</option>
+<option value="645">MDS 9000 Series Multilayer</option>
+<option value="646">Nexus 3600 Platform</option>
+<option value="647">Nexus 5500 Series</option>
+<option value="648">Nexus 5600 Series</option>
+<option value="649">Nexus 6000 Series</option>
+<option value="650">UCS 6200 Fabric Interconnects</option>
+<option value="651">UCS 6300 Fabric Interconnects</option>
+<option value="652">Firepower 4100 Series</option>
+<option value="654">Firepower 9300 Security Appliances</option>
+<option value="655">Nexus 9000 Series in Standalone NX-OS Mode</option>
+<option value="657">UCS 6200 Series Fabric Interconnects</option>
+<option value="658">UCS 6300 Series Fabric Interconnects</option>
+<option value="659">UCS 6400 Series Fabric Interconnects</option>
+<option value="660">UCS C125 M5 Rack Server Node</option>
+<option value="661">UCS C220 M4 Rack Server</option>
+<option value="662">UCS C220 M5 Rack Server</option>
+<option value="663">UCS C240 M4 Rack Server</option>
+<option value="664">UCS C240 M5 Rack Server</option>
+<option value="665">UCS C460 M4 Rack Server</option>
+<option value="666">UCS C480 M5 Rack Server</option>
+<option value="667">MDS 9000 Series</option>
+<option value="668">Nexus 1000 Virtual Edge</option>
+<option value="669">Nexus 1000V for Microsoft Hyper-V</option>
+<option value="670">UCS 6200 Series</option>
+<option value="671">UCS 6300 Series</option>
+<option value="672">UCS 6400 Series</option>
+<option value="673">Nexus 9000 Series</option>
+<option value="674">Firepower 9300 Series</option>
+<option value="675">Nexus 9500 R-Series Platform</option>
+<option value="676">Nexus 5600 Platform</option>
+<option value="677">Nexus 1000V for VMware vSphere</option>
+<option value="678">MDS 9700 Series Multilayer Directors</option>
+<option value="679">vBond Orchestrator Software</option>
+<option value="680">vEdge 100 Series Routers</option>
+<option value="681">vEdge 1000 Series Routers</option>
+<option value="682">vEdge 2000 Series Routers</option>
+<option value="683">vEdge 5000 Series Routers</option>
+<option value="684">vEdge Cloud Router Platform</option>
+<option value="685">vManage Network Management Software</option>
+<option value="686">vSmart Controller Software</option>
+<option value="687">TelePresence Integrator C Series</option>
+<option value="688">TelePresence EX Series</option>
+<option value="689">TelePresence MX Series</option>
+<option value="690">TelePresence SX Series</option>
+<option value="691">Webex Room Series</option>
+<option value="693">Virtualized Packet Core-Single Instance (VPC-SI)</option>
+<option value="694">Virtualized Packet Core-Distributed Instance (VPC-DI)</option>
+<option value="695">MDS 9000 Series Multilayer Switches</option>
+<option value="696">Nexus 5500 Platform</option>
+<option value="697">Nexus 1000V Switch for Microsoft Hyper-V</option>
+<option value="699">ASR 903 - 400G</option>
+<option value="700">ASR 907 - 400G</option>
+<option value="701">CBR-8</option>
+<option value="702">NIM-1GE-CU-SFP</option>
+<option value="703">NIM-2GE-CU-SFP</option>
+<option value="704">SM-X-PVDM-1000</option>
+<option value="705">SM-X-PVDM-2000</option>
+<option value="706">SM-X-PVDM-3000</option>
+<option value="707">SM-X-PVDM-500</option>
+<option value="708">A900-RSP2A-128</option>
+<option value="709">A900-RSP2A-64</option>
+<option value="710">A900-RSP3C-200</option>
+<option value="711">ASR-920-10SZ-PD</option>
+<option value="712">ASR-920-20SZ-M</option>
+<option value="713">ASR-920-24SZ-IM</option>
+<option value="714">C6800-16P10G-XL</option>
+<option value="715">C6800-32P10G-XL</option>
+<option value="716">C6800-8P10G-XL</option>
+<option value="717">C6800-8P40G-XL</option>
+<option value="718">C6800-SUP6T</option>
+<option value="719">C6800-SUP6T-XL</option>
+<option value="720">ASR-920-12SZ-A</option>
+<option value="721">ASR-920-12SZ-D</option>
+<option value="722">ASR-920-12CZ-A</option>
+<option value="723">ASR-920-12CZ-D</option>
+<option value="724">ASR-920-24TZ-M</option>
+<option value="725">ASR-920-24SZ-M</option>
+<option value="726">ASR-920-4SZ-A</option>
+<option value="727">ASR-920-4SZ-D</option>
+<option value="728">ASR-920-12SZ-IM-CC</option>
+<option value="729">ASR-920-12SZ-IM</option>
+<option value="730">Cisco Catalyst 9600</option>
+<option value="731">CBR-CCAP-LC-40G-R</option>
+<option value="732">Cisco 1120</option>
+<option value="733">Cisco 1240</option>
+<option value="734">Cisco 809</option>
+<option value="735">Cisco 829</option>
+<option value="736">C6816-X-LE</option>
+<option value="737">C6824-X-LE-40G</option>
+<option value="738">C6832-X-LE</option>
+<option value="739">C6840-X-LE-40G</option>
+<option value="740">A99-16X100GE-X-SE</option>
+<option value="741">A9K-16X100GE-TR</option>
+<option value="742">A9K-16X100GE-CM</option>
+<option value="743">A99-32X100GE-TR</option>
+<option value="744">A99-32X100GE-CM</option>
+<option value="745">A9K-RSP5-TR</option>
+<option value="746">A9K-RSP5-SE</option>
+<option value="747">A99-RP3-TR</option>
+<option value="748">A99-RP3-SE</option>
+<option value="749">NC55-MOD-A-S</option>
+<option value="750">NC55-24H12F-SE</option>
+<option value="751">NC55-36X100G-A-SE</option>
+<option value="752">NC55-5504-FC</option>
+<option value="753">NC55-5516-FC</option>
+<option value="754">NCS-55A2-MOD-S</option>
+<option value="755">NCS-55A2-MOD-HD-S</option>
+<option value="756">NCS-55A2-MOD-HX-S</option>
+<option value="757">NCS-55A2-MOD-SE-S</option>
+<option value="758">NC55A2-MOD-SE-H-S</option>
+<option value="759">NCS-5501-SE</option>
+<option value="760">NCS-5501</option>
+<option value="761">NCS-5502-SE</option>
+<option value="762">NCS-5502</option>
+<option value="763">NCS-55A1-24H</option>
+<option value="764">NCS-55A1-36H-S</option>
+<option value="765">NCS-55A1-36H-SE-S</option>
+<option value="766">Network Convergence System 1001</option>
+<option value="767">Network Convergence System 1002</option>
+<option value="768">Network Convergence System 5001</option>
+<option value="769">Network Convergence System 5002</option>
+<option value="770">N540-ACC-SYS</option>
+<option value="771">N540-24Z8Q2C-M</option>
+<option value="772">N540-24Z8Q2C-SYS</option>
+<option value="773">N540X-ACC-SYS</option>
+<option value="774">NC55-6X200-DWDM-S</option>
+<option value="775">NC55-36X100G-S</option>
+<option value="776">N3K-C31108PC-V</option>
+<option value="777">N3K-C31108TC-V</option>
+<option value="778">N3K-C3132C-Z</option>
+<option value="779">N3K-C3264C-E</option>
+<option value="780">N9K-C9332C</option>
+<option value="781">N9K-C9364C</option>
+<option value="782">N9K-SUP-A</option>
+<option value="783">N9K-SUP-B</option>
+<option value="784">N9K-C9236C</option>
+<option value="785">N9K-C92160YC-X</option>
+<option value="786">N9K-C92300YC</option>
+<option value="787">N9K-C92304QC</option>
+<option value="788">N9K-C9272Q</option>
+<option value="789">N9K-C93180YC-FX</option>
+<option value="790">N9K-C9348GC-FXP</option>
+<option value="791">N9K-C93108TC-FX</option>
+<option value="792">N9K-C9232C</option>
+<option value="793">N9K-C93240YC-FX2</option>
+<option value="794">N9K-C93180YC-EX</option>
+<option value="795">N9K-C93108TC-EX</option>
+<option value="796">N9K-C93180LC-EX</option>
+<option value="797">N9K-SUP-A+</option>
+<option value="798">N9K-SUP-B+</option>
+<option value="799">DS-X9334-K9</option>
+<option value="800">N7K-M348XP-25L</option>
+<option value="801">N77-M312CQ-26L</option>
+<option value="802">N7K-M324FQ-25L</option>
+<option value="803">N77-M348XP-23L</option>
+<option value="804">N77-SUP3E</option>
+<option value="805">DS-X9648-1536K9</option>
+<option value="806">Intel Dual Band Wireless-AC 7260</option>
+<option value="807">Intel Dual Band Wireless-N 7260</option>
+<option value="808">Intel Wireless-N 7260</option>
+<option value="809">Intel Dual Band Wireless-AC 7260 for Desktop</option>
+<option value="810">Intel Dual Band Wireless-AC 7265 (Rev. C)</option>
+<option value="811">Intel Dual Band Wireless-N 7265 (Rev. C)</option>
+<option value="812">Intel Wireless-N 7265 (Rev. C)</option>
+<option value="813">Intel Dual Band Wireless-AC 3165</option>
+<option value="814">Intel Dual Band Wireless-AC 7265 (Rev. D)</option>
+<option value="815">Intel Dual Band Wireless-N 7265 (Rev. D)</option>
+<option value="816">Intel Wireless-N 7265 (Rev. D)</option>
+<option value="817">Intel Dual Band Wireless-AC 3168</option>
+<option value="818">Intel Tri-Band Wireless-AC 17265</option>
+<option value="819">Intel Dual Band Wireless-AC 8260</option>
+<option value="820">Intel Tri-Band Wireless-AC 18260</option>
+<option value="821">Intel Dual Band Wireless-AC 8265</option>
+<option value="822">Intel Dual Band Wireless-AC 8265 Desktop Kit</option>
+<option value="823">Intel Tri-Band Wireless-AC 18265</option>
+<option value="824">Intel Wireless-AC 9560</option>
+<option value="825">Intel Wireless-AC 9461</option>
+<option value="826">Intel Wireless-AC 9462</option>
+<option value="827">Intel Wireless-AC 9260</option>
+<option value="828">Intel Wi-Fi 6 AX200</option>
+<option value="829">Intel Wi-Fi 6 AX201</option>
+<option value="830">Intel Dual Band Wireless-AC 3160</option>
+<option value="831">Cisco UCS C-Series</option>
+<option value="832">System Z9</option>
+<option value="833">IP Phone 8811</option>
+<option value="834">IP Phone 8841</option>
+<option value="835">IP Phone 8845</option>
+<option value="836">IP Phone 8845 with Multiplatform Firmware</option>
+<option value="837">IP Phone 8851</option>
+<option value="839">Cisco 2500 Series Connected Grid Switches</option>
+<option value="840">Cisco Connected Grid Ethernet Switch Module Interface Card</option>
+<option value="841">Cisco Industrial Ethernet 2000 Series Switches</option>
+<option value="842">Cisco Industrial Ethernet 3000 Series Switches</option>
+<option value="843">Cisco Industrial Ethernet 3010 Series Switches</option>
+<option value="844">Cisco Industrial Ethernet 4000 Series Switches</option>
+<option value="845">Cisco Industrial Ethernet 4010 Series Switches</option>
+<option value="846">Cisco Industrial Ethernet 5000 Series Switches</option>
+<option value="847">Cisco ASA 5506-X</option>
+<option value="848">Cisco ASA 5506-X with FirePOWER Services</option>
+<option value="849">Cisco ASA 5506H-X</option>
+<option value="850">Cisco ASA 5506H-X with FirePOWER Services</option>
+<option value="851">Cisco ASA 5506W-X</option>
+<option value="852">Cisco ASA 5506W-X with FirePOWER Services</option>
+<option value="853">Cisco ASA 5508-X</option>
+<option value="854">Cisco ASA 5508-X with FirePOWER Services</option>
+<option value="855">Cisco ASA 5516-X</option>
+<option value="856">Cisco ASA 5516-X with FirePOWER Services</option>
+<option value="857">S4500 Series</option>
+<option value="858">S4600 Series</option>
+<option value="859">NVIDIA Jetson TX2</option>
+<option value="861">Cisco UCS S-Series in standalone mode</option>
+<option value="862">Cisco 5000 Series ENCS Platforms</option>
+<option value="863">Cisco UCS E-Series</option>
+<option value="864">Catalyst 3650 Series</option>
+<option value="865">Catalyst 3850 Series</option>
+<option value="866">Catalyst 4500E Supervisor Engine 8-E</option>
+<option value="867">Cisco 5760 Wireless LAN Controllers</option>
+<option value="868">Remote PHY 120</option>
+<option value="869">Remote PHY 220</option>
+<option value="870">Remote PHY Shelf 7200</option>
+<option value="871">Cisco AsyncOS</option>
+<option value="872">Telepresence Codec C40</option>
+<option value="873">vEdge Cloud</option>
+<option value="874">AMP 7150</option>
+<option value="875">AMP 8150</option>
+<option value="876">Cisco 4221 Integrated Services Router</option>
+<option value="877">Cisco 4331 Integrated Services Router</option>
+<option value="878">Cisco 4321 Integrated Services Router</option>
+<option value="879">Cisco 4431 Integrated Services Router</option>
+<option value="880">Cisco 4451-X Integrated Services Router</option>
+<option value="881">Cisco 4351 Integrated Services Router</option>
+<option value="882">Cisco Cloud Services Router 1000V</option>
+<option value="883">Cisco ISR 4000 Series</option>
+<option value="884">Cisco ASR 9000v Series</option>
+<option value="885">Cisco ASR 9001 Series</option>
+<option value="886">Cisco ASR 9006 Series</option>
+<option value="887">Cisco ASR 9010 Series</option>
+<option value="888">Cisco ASR 9901 Series</option>
+<option value="889">Cisco ASR 9904 Series</option>
+<option value="890">Cisco ASR 9906 Series</option>
+<option value="892">Cisco ASR 9912 Series</option>
+<option value="893">Cisco ASR 9922 Series</option>
+<option value="894">Cisco 510 WPAN Industrial Router</option>
+<option value="895">Cisco CGR 1000 Compute Module</option>
+<option value="896">Cisco Industrial Ethernet 4000 Series</option>
+<option value="897">Cisco IC3000 Industrial Compute Gateway</option>
+<option value="898">Cisco Unified Border Element (CUBE)</option>
+<option value="899">Cisco Unified Communications Manager Express (CME)</option>
+<option value="900">Cisco IOS Gateways with Session Initiation Protocol (SIP)</option>
+<option value="901">Cisco TDM Gateways</option>
+<option value="902">Cisco Unified Survivable Remote Site Telephony (SRST)</option>
+<option value="903">Cisco Business Edition 4000 (BE4K)</option>
+<option value="904">Cisco Catalyst 4500 Supervisor Engine 6-E</option>
+<option value="905">Cisco Catalyst 4500 Supervisor Engine 6L-E</option>
+<option value="906">Cisco Catalyst 4900M</option>
+<option value="907">Cisco Catalyst 4948E Ethernet</option>
+<option value="908">Cisco Catalyst 4948E-F Ethernet</option>
+<option value="909">Cisco 1100 Integrated Services Routers</option>
+<option value="910">Cisco 4200 Integrated Services Routers</option>
+<option value="911">Cisco 4300 Integrated Services Routers</option>
+<option value="912">Cisco Cloud Services Router (CSR) 1000V Series</option>
+<option value="913">Cisco Enterprise Network Compute System</option>
+<option value="914">Cisco Integrated Services Virtual Router</option>
+<option value="916">Cisco Firepower 1000 Series</option>
+<option value="917">Cisco Firepower 9300 Series</option>
+<option value="919">Firepower 2100 Series</option>
+<option value="920">Firepower Threat Defense Virtual (FTDv)</option>
+<option value="921">MX2008</option>
+<option value="922">MX2010</option>
+<option value="923">MX2020</option>
+<option value="924">MX480</option>
+<option value="925">MX960</option>
+<option value="926">Juniper NFX Series</option>
+<option value="927">Juniper MX Series</option>
+<option value="928">Juniper SRX 5000 Series</option>
+<option value="929">SPA112 2-Port Phone Adapter</option>
+<option value="930">SPA122 ATA with Router devices</option>
+<option value="932">Catalyst 9100</option>
+<option value="937">Cisco Small Business 250 Series</option>
+<option value="938">Cisco Small Business 350 Series</option>
+<option value="939">Cisco Small Business 350X Series</option>
+<option value="940">Cisco Small Business 550X Series</option>
+<option value="945">Cisco Aironet 1830</option>
+<option value="946">Cisco Aironet 1850</option>
+<option value="947">EX2300-C</option>
+<option value="948">SRX1500</option>
+<option value="949">Cisco 12000 Series</option>
+<option value="950">Cisco Carrier Routing System</option>
+<option value="951">Cisco Network Convergence System 4000 Series</option>
+<option value="952">Cisco Network Convergence System 6000 Series</option>
+<option value="953">Cisco 4400 Series Integrated Services Routers</option>
+<option value="954">Cisco ASR 900 Series</option>
+<option value="955">Cisco Email Security Appliance</option>
+<option value="956">SRX4000</option>
+<option value="957">vSRX Junos</option>
+<option value="958">ViPNet Coordinator HW</option>
+<option value="959">ViPNet Coordinator KB</option>
+<option value="961">Терминал микропроцессорный серии ЭКРА 200</option>
+<option value="962">USG6330</option>
+<option value="963">USG9500</option>
+<option value="966">ASR 9000 Series Aggregation Services Routers</option>
+<option value="967">IOS XRv 9000 Router</option>
+<option value="968">Network Convergence System (NCS) 540 Series Routers</option>
+<option value="969">Network Convergence System (NCS) 560 Series Routers</option>
+<option value="970">Network Convergence System (NCS) 1000 Series Routers</option>
+<option value="971">Network Convergence System (NCS) 5000 Series Routers</option>
+<option value="972">Network Convergence System (NCS) 5500 Series Routers</option>
+<option value="973">Network Convergence System (NCS) 6000 Series Routers</option>
+<option value="974">Nexus 1000 Virtual Edge for VMware vSphere</option>
+<option value="975">NC-302</option>
+<option value="976">NC-210</option>
+<option value="977">NC-220</option>
+<option value="978">NC-110</option>
+<option value="979">NC-201M</option>
+<option value="980">NC-202</option>
+<option value="981">NC-301</option>
+<option value="982">NC-310</option>
+<option value="983">NC-400</option>
+<option value="984">NC-230</option>
+<option value="985">cMT-SVR-100\200</option>
+<option value="986">XP-8741-Atom</option>
+<option value="987">HoloLens</option>
+<option value="989">Cisco 4300 Series</option>
+<option value="990">Catalyst 9800-L</option>
+<option value="991">Catalyst 9800 Series</option>
+<option value="992">800 Series Industrial Integrated Services Routers (Industrial ISRs)</option>
+<option value="993">800 Series Integrated Services Routers (ISRs)</option>
+<option value="994">1000 Series Connected Grid Routers (CGR1000) Compute Module</option>
+<option value="995">1000 Series ISRs</option>
+<option value="996">4000 Series ISRs</option>
+<option value="997">Catalyst 9x00 Series Switches</option>
+<option value="998">Catalyst IE3400 Rugged Series Switches</option>
+<option value="999">Embedded Services 3300 Series Switches</option>
+<option value="1000">IR510 WPAN Industrial Routers</option>
+<option value="1001">Catalyst 2960-L Series Switches</option>
+<option value="1002">Catalyst CDB-8P Switches</option>
+<option value="1003">Cisco ASR 920 Series Aggregation Services Router model ASR920-12SZ-IM</option>
+<option value="1004">PA-7080</option>
+<option value="1005">PA-7050</option>
+<option value="1006">MacOS</option>
+<option value="1007">vManage Software</option>
+<option value="1008">vEdge Routers</option>
+<option value="1009">ENCS 5400-W</option>
+<option value="1011">CSP 5000-W</option>
+<option value="1012">Nexus 1100 Series</option>
+<option value="1013">8000 Series Routers</option>
+<option value="1015">IOS XR, SW only</option>
+<option value="1016">Network Convergence System 540 Routers</option>
+<option value="1017">Network Convergence System 5500 Series</option>
+<option value="1018">ESA software</option>
+<option value="1019">SMA software</option>
+<option value="1020">WSA software</option>
+<option value="1021">RV340W Dual WAN Gigabit Wireless-AC VPN Router</option>
+<option value="1022">RV340 Dual WAN Gigabit VPN Router</option>
+<option value="1023">RV345 Dual WAN Gigabit VPN Router</option>
+<option value="1024">RV345P Dual WAN Gigabit POE VPN Router</option>
+<option value="1025">High-End SRX Series</option>
+<option value="1027">EX9200 Series</option>
+<option value="1028">PTX Series</option>
+<option value="1029">PTX1000 Series</option>
+<option value="1030">PTX10000 Series</option>
+<option value="1031">vMX</option>
+<option value="1032">MX150</option>
+<option value="1033">MPC10E</option>
+<option value="1034">MPC11E</option>
+<option value="1035">PTX10001</option>
+<option value="1036">PTX10003</option>
+<option value="1037">ASR 920 Series</option>
+<option value="1038">ASR 1000 Series</option>
+<option value="1039">Catalyst 9000 Series</option>
+<option value="1040">Catalyst 9200 Series</option>
+<option value="1042">SRX4100</option>
+<option value="1043">SRX4200</option>
+<option value="1044">Catalyst 9300</option>
+<option value="1045">Catalyst 9400</option>
+<option value="1046">Catalyst 9500</option>
+<option value="1047">Catalyst 9100 AP</option>
+<option value="1048">Cisco Aironet 1810 Series APs</option>
+<option value="1049">Cisco Aironet 1815 Series APs</option>
+<option value="1050">Cisco Aironet 1840 Series APs</option>
+<option value="1051">Cisco Aironet 1850 Series APs</option>
+<option value="1052">Business 100 Series APs</option>
+<option value="1053">Business 200 Series APs</option>
+<option value="1054">Catalyst IW 6300 APs</option>
+<option value="1055">ESW6300 Series APs</option>
+<option value="1056">Integrated Access Point on 1100 Integrated Services Routers</option>
+<option value="1057">Cisco 4461</option>
+<option value="1058">Cisco Firepower 4110 Series</option>
+<option value="1059">Windows</option>
+<option value="1061">CentOS 7</option>
+<option value="1062">My Cloud Mirror Gen2</option>
+<option value="1063">My Cloud EX2 Ultra</option>
+<option value="1064">My Cloud EX4100</option>
+<option value="1065">My Cloud PR2100</option>
+<option value="1066">My Cloud PR4100</option>
+<option value="1067">INOI R7</option>
+<option value="1068">Aquarius CMP NS220</option>
+<option value="1069">Byterg MVK-2020</option>
+<option value="1070">Cloud Services Router 1000V</option>
+<option value="1071">Meraki MX64</option>
+<option value="1072">Meraki MX64W</option>
+<option value="1073">Meraki MX67</option>
+<option value="1074">Meraki MX67C</option>
+<option value="1075">Meraki MX67W</option>
+<option value="1076">Meraki MX68</option>
+<option value="1077">Meraki MX68CW</option>
+<option value="1078">Meraki MX68W</option>
+<option value="1079">Meraki MX100</option>
+<option value="1080">Meraki MX84</option>
+<option value="1081">Meraki MX250</option>
+<option value="1082">Meraki MX450</option>
+<option value="1083">vEdge Cloud Routers</option>
+<option value="1084">ASR 5000 Series Aggregation Services Routers</option>
+<option value="1085">86-bit</option>
+<option value="1086">NCS1K</option>
+<option value="1087">RSPE</option>
+<option value="1088">RSP</option>
+<option value="1089">OS2</option>
+<option value="1090">OpenBAT</option>
+<option value="1091">BAT450-F</option>
+<option value="1092">NFX350</option>
+<option value="1093">QFX5210</option>
+<option value="1094">QFX5120</option>
+<option value="1095">EX4650</option>
+<option value="1096">Catalyst 8000V Edge</option>
+<option value="1098">Catalyst 8200 Series Edge</option>
+<option value="1099">Catalyst 8300 Series Edge</option>
+<option value="1100">Cloud Services Router 1000V Series</option>
+<option value="1102">5400 Enterprise Network Compute System with ISRv</option>
+<option value="1103">Catalyst 9300L Series</option>
+<option value="1104">Cisco ESR6300 Embedded Series</option>
+<option value="1105">Cisco Catalyst 4500 Series</option>
+<option value="1106">Cisco Catalyst 4500-X Series</option>
+<option value="1107">Catalyst IE3200 Rugged Series Switches</option>
+<option value="1108">Catalyst IE3300 Rugged Series Switches</option>
+<option value="1109">Catalyst IE3400 Heavy Duty Series Switches</option>
+<option value="1111">DVPSimulator EH2</option>
+<option value="1112">DVPSimulator EH3</option>
+<option value="1113">DVPSimulator ES2</option>
+<option value="1114">DVPSimulator SE</option>
+<option value="1115">DVPSimulator SS2</option>
+<option value="1116">AHSIM_5x0</option>
+<option value="1117">AHSIM_5x1</option>
+<option value="1119">Catalyst 8500L Series</option>
+<option value="1120">SRX4600</option>
+<option value="1121">SRX5000</option>
+<option value="1122">iOS</option>
+<option value="1123">UNIX</option>
+<option value="1124">EX8200/VC (XRE)</option>
+<option value="1125">QFabric Series</option>
+<option value="1126">PTX10008</option>
+<option value="1127">QFX5220</option>
+<option value="1128">MX Series</option>
+<option value="1129">PTX1000</option>
+<option value="1130">QFX Switching</option>
+<option value="1131">QFabric System</option>
+<option value="1132">SRX100</option>
+<option value="1133">SRX210</option>
+<option value="1134">SRX220</option>
+<option value="1135">SRX240m</option>
+<option value="1136">SRX300</option>
+<option value="1137">SRX320</option>
+<option value="1138">SRX340</option>
+<option value="1139">SRX345</option>
+<option value="1140">SRX550m</option>
+<option value="1141">SRX650</option>
+<option value="1143">ACX5800</option>
+<option value="1144">MX10000 Series</option>
+<option value="1145">MX240</option>
+<option value="1146">QFX5000</option>
+<option value="1148">ATM Dispenser Controller</option>
+<option value="1149">CPU: STM STR710FZ2T6</option>
+<option value="1150">Catalyst 9800-CL Wireless Controllers for Cloud</option>
+<option value="1151">Embedded Wireless Controller on Catalyst Access Points</option>
+<option value="1153">Catalyst 9800 Wireless Controllers</option>
+<option value="1154">Catalyst 8000 Series Edge Platforms</option>
+<option value="1155">Cisco ASR 920 Series Aggregation Services Routers</option>
+<option value="1156">Fedora 34</option>
+<option value="1157">Fedora 35</option>
+<option value="1158">Chrome OS</option>
+<option value="1159">Windows 10</option>
+<option value="1160">Windows 8.1</option>
+<option value="1161">AX</option>
+<option value="1162">asr_901-6cz-ft-d</option>
+<option value="1163">asr_901-6cz-ft-a</option>
+<option value="1164">asr_901-6cz-fs-d</option>
+<option value="1165">asr_901-6cz-fs-a</option>
+<option value="1166">asr_901-6cz-f-d</option>
+<option value="1167">asr_901-6cz-f-a</option>
+<option value="1168">Router 7600</option>
+<option value="1169">asr_901-4c-ft-d</option>
+<option value="1170">asr_901-4c-f-d</option>
+<option value="1171">asr_901-12c-ft-d</option>
+<option value="1172">asr_901-12c-f-d</option>
+<option value="1173">Catalyst 9105</option>
+<option value="1174">Catalyst 9115</option>
+<option value="1175">Catalyst 9117</option>
+<option value="1176">Catalyst 9120</option>
+<option value="1177">Catalyst 9124</option>
+<option value="1178">Catalyst 9130</option>
+<option value="1179">Catalyst 9800-40</option>
+<option value="1180">Catalyst 9800-40 Wireless controller</option>
+<option value="1181">Catalyst 9800-80</option>
+<option value="1182">Catalyst 9800-80 Wireless controller</option>
+<option value="1183">Catalyst 9800-CL</option>
+<option value="1184">Catalyst 9800-L-C</option>
+<option value="1185">Catalyst 9800-L-F</option>
+<option value="1186">ASR 1000</option>
+<option value="1187">ASR 1000 ESP100</option>
+<option value="1189">Cisco ASR 9902</option>
+<option value="1190">Cisco ASR 9903</option>
+<option value="1191">ASR 1000 X</option>
+<option value="1192">ASR 1000 Series RP2</option>
+<option value="1193">ASR 1000 Series RP3</option>
+<option value="1194">ASR 1001</option>
+<option value="1195">ASR 1001-HX</option>
+<option value="1196">ASR 1001-HX-R</option>
+<option value="1197">ASR 1001-X</option>
+<option value="1198">ASR 1001-X R</option>
+<option value="1199">ASR 1002</option>
+<option value="1200">ASR 1002-HX</option>
+<option value="1201">ASR 1002-HX R</option>
+<option value="1202">ASR 1002-X</option>
+<option value="1204">ASR 1002-X R</option>
+<option value="1205">ASR 1004</option>
+<option value="1206">ASR 1006-X</option>
+<option value="1207">ASR 1006</option>
+<option value="1208">ASR 1009-X</option>
+<option value="1209">ASR 1013</option>
+<option value="1210">ASR 1023</option>
+<option value="1211">1100 Series ISRs</option>
+<option value="1212">1100-4G Series ISRs (6G)</option>
+<option value="1213">1100-4P Series ISRs</option>
+<option value="1216">1101 Series ISRs</option>
+<option value="1217">1101-4P Series ISP</option>
+<option value="1218">1109 Series ISRs</option>
+<option value="1219">1109-2P Series ISRs</option>
+<option value="1220">1109-4P Series ISRs</option>
+<option value="1221">1111X Series ISRs</option>
+<option value="1222">1111X-8P Series ISRs</option>
+<option value="1223">111X Series ISRs</option>
+<option value="1224">1120 Series ISRs</option>
+<option value="1225">1160 Series ISRs</option>
+<option value="1226">422 Series ISRs</option>
+<option value="1227">4221 Series ISRs</option>
+<option value="1228">4321 Series ISRs</option>
+<option value="1229">4331 Series ISRs</option>
+<option value="1230">4351 Series ISRs</option>
+<option value="1231">4431 Series ISRs</option>
+<option value="1232">4451 Series ISRs</option>
+<option value="1233">4461 Series ISRs</option>
+<option value="1243">ACX710 Series</option>
+<option value="1244">x86 Intel</option>
+<option value="1245">ACX1000</option>
+<option value="1246">ACX1100</option>
+<option value="1247">ACX2100</option>
+<option value="1248">ACX2200</option>
+<option value="1249">ACX4000</option>
+<option value="1250">ACX500</option>
+<option value="1251">ACX5048</option>
+<option value="1252">ACX5096</option>
+<option value="1254">F+ Life Tab Plus</option>
+<option value="1255">Juniper ACX5448</option>
+<option value="1256">Juniper MX-SPC3</option>
+<option value="1258">Cisco Nexus 9200 Platform Switches</option>
+<option value="1259">Cisco Nexus 9300 Platform Switches</option>
+<option value="1303">3504 Wireless Controller</option>
+<option value="1304">5520 Wireless Controller</option>
+<option value="1305">8540 Wireless Controller</option>
+<option value="1306">Catalyst 8500 Series</option>
+<option value="1307">Citrix Hypervisor</option>
+<option value="1308">Red Hat Enterprise Linux with KVM</option>
+<option value="1309">Cisco Catalyst Micro Switches</option>
+<option value="1310">Catalyst Digital Building Series Switches</option>
+<option value="1311">5500NAC</option>
+<option value="1312">5500SHAC</option>
+<option value="1313">5500NAC2</option>
+<option value="1314">5500AC2</option>
+<option value="1315">D0-06 series CPU</option>
+<option value="1316">Cisco Catalyst 6800 Series</option>
+<option value="1317">Integrated Services Routers Generation 2 (ISR G2)</option>
+<option value="1318">x86-64-bit</option>
+<option value="1321">PTX 500Series</option>
+<option value="1322">PTX 500 Series</option>
+<option value="1323">Redmi Note 11</option>
+<option value="1324">Redmi Note 9T</option>
+<option value="1325">SuperMassive 92xx/94xx/96xx (GEN6+)</option>
+<option value="1326">SOHO W</option>
+<option value="1327">SuperMassive 10000 Series</option>
+<option value="1328">NSv (Virtual: VMWare/Hyper-V/AWS/Azure/KVM)</option>
+<option value="1329">NSv (Virtual: GEN7)</option>
+<option value="1330">NSsp (GEN7)</option>
+<option value="1331">Mashtab TrustPhone T1</option>
+<option value="1332">Industrial Ethernet Switches</option>
+<option value="1333">Micro Switches</option>
+<option value="1334">IOS XE Switches</option>
+<option value="1335">TZ</option>
+<option value="1336">NSa</option>
+<option value="1337">NSsp 12K</option>
+<option value="1338">SuperMassive 9800</option>
+<option value="1339">SuperMassive 10k</option>
+<option value="1340">VMware vCenter</option>
+<option value="1341">cSRX Series</option>
+<option value="1342">Catalyst 3600 Series Switches</option>
+<option value="1343">Catalyst 3800 Series Switches</option>
+<option value="1344">Catalyst 9200 Series Switches</option>
+<option value="1345">Catalyst 9300 Series Switches</option>
+<option value="1346">Catalyst 9400 Series Switches</option>
+<option value="1347">Catalyst 9500 Series Switches</option>
+<option value="1348">Catalyst 9600 Series Switches</option>
+<option value="1349">Catalyst 9800 Series Wireless Controllers</option>
+<option value="1350">Catalyst 9800 Embedded Wireless Controller for Catalyst 9300, 9400, and 9500 Series Switches</option>
+<option value="1351">Intel Wi-Fi 6 AX210</option>
+<option value="1352">Intel Wi-Fi 6E AX211</option>
+<option value="1353">PTX10004</option>
+<option value="1354">PTX10016</option>
+<option value="1355">Intel 8254x</option>
+<option value="1356">Intel 8255x</option>
+<option value="1357">TZ270</option>
+<option value="1358">TZ270W</option>
+<option value="1359">TZ370</option>
+<option value="1360">TZ370W</option>
+<option value="1361">TZ470</option>
+<option value="1362">TZ470W</option>
+<option value="1363">TZ570</option>
+<option value="1364">TZ570W</option>
+<option value="1365">TZ570P</option>
+<option value="1366">TZ670</option>
+<option value="1367">NSa 2700</option>
+<option value="1368">NSa 3700</option>
+<option value="1369">NSa 4700</option>
+<option value="1370">NSa 5700</option>
+<option value="1371">NSa 6700</option>
+<option value="1372">NSsp 10700</option>
+<option value="1373">NSsp 11700</option>
+<option value="1374">NSsp 13700</option>
+<option value="1375">NSv 270</option>
+<option value="1376">NSv 470</option>
+<option value="1377">NSv 870</option>
+<option value="1378">NSsp 15700</option>
+<option value="1379">NSv 10</option>
+<option value="1380">NSv 25</option>
+<option value="1381">NSv 50</option>
+<option value="1382">NSv 100</option>
+<option value="1383">NSv 200</option>
+<option value="1384">NSv 300</option>
+<option value="1385">NSv 400</option>
+<option value="1386">NSv 800</option>
+<option value="1387">NSv 1600</option>
+<option value="1388">EX46xx Series</option>
+<option value="1389">Catalyst Access Points (COS-APs)</option>
+<option value="1390">IOS XE-based devices configured with IOx</option>
+<option value="1391">QTS от 4.3.4 до 4.4.0</option>
+<option value="1392">QTS от 4.3.0 до 4.3.3</option>
+<option value="1393">QTS 4.4.1</option>
+<option value="1394">QTS 4.2.6</option>
+<option value="1395">QNAP NAS</option>
+<option value="1396">IBR600</option>
+<option value="1397">UCS 6500 Series Fabric Interconnects</option>
+<option value="1398">Cisco ASR 9900</option>
+<option value="1399">SiPass integrated AC5102 (ACC-G2)</option>
+<option value="1400">SiPass integrated ACC-AP</option>
+<option value="1406">Cisco Nexus 1000V for VMware Switch</option>
+<option value="1408">SierraWireless gx450</option>
+<option value="1409">SierraWireless lx40</option>
+<option value="1410">SierraWireless lx60</option>
+<option value="1411">SierraWireless mp70</option>
+<option value="1412">SierraWireless rv50</option>
+<option value="1413">SierraWireless rv50x</option>
+<option value="1414">SierraWireless rv55</option>
+<option value="1415">Aruba AP-305/7008</option>
+<option value="1416">DIR-853</option>
+<option value="1417">Asus RT-N10</option>
+<option value="1418">1000 Series Integrated Services Routers</option>
+<option value="1419">Cloud Services Router (CSR) 1000V Series</option>
+<option value="1420">QVR Pro</option>
+<option value="1421">QVR</option>
+<option value="1422">Pixel</option>
+<option value="1423">Red Hat Enterprise Linux</option>
+<option value="1424">Catalyst IW6300 Heavy Duty Series APs</option>
+<option value="1425">Catalyst IW9165 Heavy Duty Series</option>
+<option value="1426">Catalyst IW9165 Rugged Series</option>
+<option value="1427">Catalyst IW9167 Heavy Duty Series</option>
+<option value="1428">exynos</option>
+<option value="1430">JRR200</option>
+<option value="1431">RPL</option>
+<option value="1432">ADL-N</option>
+<option value="1433">ADL</option>
+<option value="1434">RKL</option>
+<option value="1435">TGL</option>
+<option value="1436">JSL</option>
+<option value="1437">Greenlow-R Server</option>
+<option value="1438">Greenlow-R Workstation</option>
+<option value="1439">Kaby Lake RVP</option>
+<option value="1440">Mehlow/Mehlow-R(CFL-S)</option>
+<option value="1441">Tatlow (RKS)</option>
+<option value="1442">WhiskeyLake</option>
+<option value="1443">CometLake-S</option>
+<option value="1444">TigerLake UP3/H</option>
+<option value="1445">AlderLake</option>
+<option value="1446">Alder Lake N</option>
+<option value="1448">Nexus 5500 Series Switches</option>
+<option value="1449">Nexus 5600 Series Switches</option>
+<option value="1450">Nexus 1000V Series Switches</option>
+<option value="1451">Nexus 1100 Series Cloud Services Platforms</option>
+<option value="1452">Nexus 2000 Series Switches</option>
+<option value="1453">Nexus 4000 Series Switches</option>
+<option value="1454">UCS 6100 Fabric Interconnects</option>
+<option value="1455">e510</option>
+<option value="1456">h320</option>
+<option value="1457">h350</option>
+<option value="1459">h510</option>
+<option value="1460">h550</option>
+<option value="1461">m510</option>
+<option value="1462">r310</option>
+<option value="1463">r320</option>
+<option value="1464">r350</option>
+<option value="1465">r510</option>
+<option value="1466">r550</option>
+<option value="1467">r610</option>
+<option value="1468">r650</option>
+<option value="1469">r710</option>
+<option value="1470">r720</option>
+<option value="1471">r730</option>
+<option value="1472">r750</option>
+<option value="1473">r760</option>
+<option value="1474">r850</option>
+<option value="1475">sz-144</option>
+<option value="1476">sz100</option>
+<option value="1477">sz300</option>
+<option value="1478">t310c</option>
+<option value="1479">t310d</option>
+<option value="1480">t310n</option>
+<option value="1481">t310s</option>
+<option value="1482">t350c</option>
+<option value="1483">t350d</option>
+<option value="1484">t350se</option>
+<option value="1485">t610</option>
+<option value="1486">t710</option>
+<option value="1487">t710s</option>
+<option value="1488">t750</option>
+<option value="1489">t750se</option>
+<option value="1490">t811-cm</option>
+<option value="1491">h500</option>
+<option value="1492">r300</option>
+<option value="1493">r700</option>
+<option value="1494">r560</option>
+<option value="1495">m510-jp</option>
+<option value="1496">p300</option>
+<option value="1497">q410</option>
+<option value="1498">q710</option>
+<option value="1499">q910</option>
+<option value="1500">t811-cm(non-spf)</option>
+<option value="1501">zd1000</option>
+<option value="1502">zd1100</option>
+<option value="1503">zd1200</option>
+<option value="1504">zd3000</option>
+<option value="1505">zd5000</option>
+<option value="1506">sz-144-federal</option>
+<option value="1507">sz300-federal</option>
+<option value="1508">ACX2K</option>
+<option value="1509">Chrome OS Flex</option>
+<option value="1511">HMISTU</option>
+<option value="1512">HMIGTO</option>
+<option value="1513">HMIGTU</option>
+<option value="1514">HMIGTUX</option>
+<option value="1515">HMIGK</option>
+<option value="1516">HMIET</option>
+<option value="1517">HMIGXU</option>
+<option value="1518">Beckhoff CX</option>
+<option value="1519">Nexus 9000 Series Switches in ACI mode</option>
+<option value="1520">UCS 6100 Series Fabric Interconnects</option>
+<option value="1521">ACX7100-32C</option>
+<option value="1522">ACX7100-48L</option>
+<option value="1523">ACX7509</option>
+<option value="1524">EX4300-MP</option>
+<option value="1525">Mediatek MT8167</option>
+<option value="1526">Mediatek MT8175</option>
+<option value="1527">Mediatek MT8183</option>
+<option value="1528">SRX5000-SPC3</option>
+<option value="1529">Secure Web Appliance</option>
+<option value="1530">Secure Email and Web Manager</option>
+<option value="1531">Secure Email Gateway</option>
+<option value="1532">Cisco Nexus 9332C</option>
+<option value="1533">Cisco Nexus 9364C</option>
+<option value="1534">Virtual Appliance</option>
+<option value="1535">Extreme Networks AP302W</option>
+<option value="1536">Extreme Networks AP305C/CX</option>
+<option value="1537">Extreme Networks AP305C-1</option>
+<option value="1538">Extreme Networks AP410C</option>
+<option value="1539">Extreme Networks AP410C-1</option>
+<option value="1540">Extreme Networks AP460C</option>
+<option value="1541">Extreme Networks AP460S6C</option>
+<option value="1542">Extreme Networks AP460S12C</option>
+<option value="1543">Extreme Networks AP510C/CX</option>
+<option value="1544">Extreme Networks AP630</option>
+<option value="1545">Extreme Networks AP650</option>
+<option value="1546">Extreme Networks AP650X</option>
+<option value="1547">Extreme Networks AP3000</option>
+<option value="1548">Extreme Networks AP3000X</option>
+<option value="1549">Extreme Networks AP4000</option>
+<option value="1550">Extreme Networks AP4000-1</option>
+<option value="1551">Extreme Networks AP5010</option>
+<option value="1552">Extreme Networks AP5050D</option>
+<option value="1553">Extreme Networks AP5050U</option>
+<option value="1554">Adtran SR400ac</option>
+<option value="1555">ASA 5506-X</option>
+<option value="1556">ASA 5506H-X</option>
+<option value="1557">ASA 5506W-X</option>
+<option value="1558">ASA 5508-X</option>
+<option value="1559">ASA 5512-X</option>
+<option value="1560">ASA 5515-X</option>
+<option value="1561">ASA 5516-X</option>
+<option value="1562">ASA 5525-X</option>
+<option value="1563">ASA 5545-X</option>
+<option value="1564">ASA 5585-X</option>
+<option value="1565">ASA 5500 Series Adaptive Security Appliances</option>
+<option value="1566">ASA 1000V Cloud Firewall</option>
+<option value="1567">Firepower 4110 Security Appliance</option>
+<option value="1568">Firepower 4120 Security Appliance</option>
+<option value="1569">Firepower 4140 Security Appliance</option>
+<option value="1570">Firepower 4150 Security Appliance</option>
+<option value="1571">Firepower 2100 Series Security Appliance</option>
+<option value="1572">NB800</option>
+<option value="1573">NG800</option>
+<option value="1574">NB1601</option>
+<option value="1575">NB1800</option>
+<option value="1576">NB1810</option>
+<option value="1577">NB2800</option>
+<option value="1578">NB2810</option>
+<option value="1579">NB3701</option>
+<option value="1580">NB3800</option>
+<option value="1582">Linux kernel</option>
+<option value="1583">Aruba 9200 Series Controllers</option>
+<option value="1584">Aruba 9000 Series Controllers</option>
+<option value="1585">Secure Firewall 3100 Series</option>
+<option value="1586">Network Convergence System 5700 Series</option>
+<option value="1587">Network Convergence Series (NCS) 5700 Series</option>
+<option value="1588">Cisco IOS XR White box (IOSXRWBD)</option>
+<option value="1589">Catalyst IR8300 Rugged Series Routers</option>
+<option value="1590">Catalyst 9800 Embedded Wireless Controller</option>
+<option value="1591">Embedded Wireless Controller on Catalyst 9100X Series Access Points</option>
+<option value="1592">Integrated Services Virtual Routers</option>
+<option value="1593">VG400 Analog Voice Gateways</option>
+<option value="1594">VG420 Analog Voice Gateways</option>
+<option value="1595">VG450 Analog Voice Gateways</option>
+<option value="1596">Catalyst IE3x00 Rugged Series Switches</option>
+<option value="1597">Catalyst IR1100 Rugged Series Routers</option>
+<option value="1598">Catalyst IR1800 Rugged Series Routers</option>
+<option value="1599">Catalyst IR8100 Heavy Duty Series Routers</option>
+<option value="1600">PTX10002</option>
+<option value="1601">FPC LC110x</option>
+<option value="1602">PTX3000</option>
+<option value="1603">PTX5000</option>
+<option value="1604">QFX10000</option>
+<option value="1605">A10 Thunder ADC</option>
+<option value="1606">QFX5000 Series</option>
+<option value="1607">EX4600 Series</option>
+<option value="1608">EX4100</option>
+<option value="1609">EX4400</option>
+<option value="1611">TZ 300</option>
+<option value="1612">TZ 300W</option>
+<option value="1613">TZ 400</option>
+<option value="1614">TZ 400W</option>
+<option value="1615">TZ 500</option>
+<option value="1616">TZ 500W</option>
+<option value="1617">TZ 600</option>
+<option value="1618">NSA 2600</option>
+<option value="1619">NSA 2650</option>
+<option value="1620">NSA 3600</option>
+<option value="1621">NSA 3650</option>
+<option value="1622">NSA 4600</option>
+<option value="1623">NSA 4650</option>
+<option value="1624">NSA 5600</option>
+<option value="1625">NSA 5650</option>
+<option value="1626">NSA 6600</option>
+<option value="1627">NSA 6650</option>
+<option value="1628">SM 9200</option>
+<option value="1629">SM 9250</option>
+<option value="1630">SM 9400</option>
+<option value="1631">SM 9450</option>
+<option value="1632">SM 9600</option>
+<option value="1633">SM 9650</option>
+<option value="1634">TZ 300P</option>
+<option value="1635">TZ 600P</option>
+<option value="1636">SOHO 250</option>
+<option value="1637">SOHO 250W</option>
+<option value="1638">TZ 350</option>
+<option value="1639">TZ 350W</option>
+<option value="1640">EX4000 Series</option>
+<option value="1641">PrestaShop</option>
+<option value="1642">Azure Stack HCI</option>
+<option value="1643">vx-1000</option>
+<option value="1644">vx-2000</option>
+<option value="1645">vx-3000</option>
+<option value="1646">vx-500</option>
+<option value="1647">vx-5000</option>
+<option value="1648">vx-6000</option>
+<option value="1649">vx-7000</option>
+<option value="1650">vx-8000</option>
+<option value="1651">vx-9000</option>
+<option value="1652">nx-10700</option>
+<option value="1653">nx-11700</option>
+<option value="1654">nx-1700</option>
+<option value="1655">nx-2700</option>
+<option value="1656">nx-3700</option>
+<option value="1657">nx-5700</option>
+<option value="1658">nx-6700</option>
+<option value="1659">nx-700</option>
+<option value="1660">nx-7700</option>
+<option value="1661">nx-8700</option>
+<option value="1662">nx-9700</option>
+<option value="1663">Sierra Wireless ES450</option>
+<option value="1664">Sierra Wireless GX450</option>
+<option value="1666">AXIS A1001</option>
+<option value="1668">AXIS A1210 (-B)</option>
+<option value="1669">AXIS A1601</option>
+<option value="1670">AXIS A1610 (-B)</option>
+<option value="1671">AXIS A8207</option>
+<option value="1672">AXIS A8207 MKII</option>
+<option value="1673">Cisco Firepower 2110</option>
+<option value="1674">Cisco Firepower 2120</option>
+<option value="1675">Cisco Firepower 2130</option>
+<option value="1676">Cisco Firepower 2140</option>
+<option value="1678">nova227</option>
+<option value="1679">nova233</option>
+<option value="1680">nova243</option>
+<option value="1681">nova246</option>
+<option value="1682">ES450</option>
+<option value="1683">GX450</option>
+<option value="1687">EX4100 Series</option>
+<option value="1688">EX4400 Series</option>
+<option value="1689">Juniper ACX7024</option>
+<option value="1690">Nexo cordless nutrunner NXA011S-36V (0608842011)</option>
+<option value="1691">Nexo cordless nutrunner NXA011S-36V-B (0608842012)</option>
+<option value="1692">Nexo cordless nutrunner NXA015S-36V (0608842001)</option>
+<option value="1693">Nexo cordless nutrunner NXA015S-36V-B (0608842006)</option>
+<option value="1694">Nexo cordless nutrunner NXA030S-36V (0608842002)</option>
+<option value="1695">Nexo cordless nutrunner NXA030S-36V-B (0608842007)</option>
+<option value="1696">Nexo cordless nutrunner NXA050S-36V (0608842003)</option>
+<option value="1697">Nexo cordless nutrunner NXA050S-36V-B (0608842008)</option>
+<option value="1698">Nexo cordless nutrunner NXA065S-36V (0608842013)</option>
+<option value="1699">Nexo cordless nutrunner NXA065S-36V-B (0608842014)</option>
+<option value="1700">Nexo cordless nutrunner NXP012QD-36V (0608842005)</option>
+<option value="1701">Nexo cordless nutrunner NXP012QD-36V-B (0608842010)</option>
+<option value="1702">Nexo cordless nutrunner NXV012T-36V (0608842015)</option>
+<option value="1703">Nexo cordless nutrunner NXV012T-36V-B (0608842016)</option>
+<option value="1704">Nexo special cordless nutrunner (0608PE2272)</option>
+<option value="1705">Nexo special cordless nutrunner (0608PE2301)</option>
+<option value="1706">Nexo special cordless nutrunner (0608PE2514)</option>
+<option value="1707">Nexo special cordless nutrunner (0608PE2515)</option>
+<option value="1708">Nexo special cordless nutrunner (0608PE2666)</option>
+<option value="1709">Nexo special cordless nutrunner (0608PE2673)</option>
+<option value="1710">PAX A920Pro</option>
+<option value="1711">PAX A50</option>
+<option value="1712">PAX A6650</option>
+<option value="1713">PAX A800</option>
+<option value="1714">PAX A77</option>
+<option value="1715">PAX A920</option>
+<option value="1716">PAX A920Max</option>
+<option value="1717">PAX D190</option>
+<option value="1718">Intel E800</option>
+<option value="1719">IOS XRd Control Plane</option>
+<option value="1720">IOS XRd vRouter</option>
+<option value="1721">NCS 540 Series Routers</option>
+<option value="1722">NCS 5700 Series Routers</option>
+<option value="1724">Intel Wi-Fi 6E AX210</option>
+<option value="1725">Intel Wi-Fi 6E AX411</option>
+<option value="1726">Intel Killer Wi-Fi 6E AX1675</option>
+<option value="1727">Intel Killer Wi-Fi 6E AX1690</option>
+<option value="1729">Killer Wireless-AC 1550i</option>
+<option value="1730">Killer Wireless-AC 1550s</option>
+<option value="1731">Killer Wi-Fi 6E AX1690i</option>
+<option value="1732">Killer Wi-Fi 6E AX1690s</option>
+<option value="1733">Killer Wi-Fi 6E AX1675x</option>
+<option value="1734">Killer Wi-Fi 6E AX1675w</option>
+<option value="1735">Killer Wi-Fi 6E AX1675i</option>
+<option value="1736">Killer Wi-Fi 6E AX1675s</option>
+<option value="1737">Killer Wi-Fi 6 AX1650i</option>
+<option value="1738">Killer Wi-Fi 6 AX1650s</option>
+<option value="1739">Intel Wi-Fi 6 AX101</option>
+<option value="1740">Intel Wi-Fi 6 AX203</option>
+<option value="1741">Killer Wi-Fi 6 AX1650</option>
+<option value="1742">Killer Wireless-AC 1550</option>
+<option value="1743">Intel Wireless-N 7265</option>
+<option value="1744">Intel Dual Band Wireless-N 7265</option>
+<option value="1745">Intel Dual Band Wireless-AC 7265</option>
+<option value="1746">Cisco 2800 Series</option>
+<option value="1747">Cisco 2970 Series</option>
+<option value="1748">CentOS</option>
+<option value="1749">Debian 10 LTS</option>
+<option value="1750">DNA Traffic Telemetry Appliance</option>
+<option value="1751">Shell</option>
+<option value="1752">Vision Pro</option>
+<option value="1753">Aruba 5400R</option>
+<option value="1754">Aruba 3810</option>
+<option value="1755">Aruba 2920</option>
+<option value="1756">Aruba 2930F</option>
+<option value="1757">Aruba 2930M</option>
+<option value="1758">Aruba 2530</option>
+<option value="1759">Aruba 2540</option>
+<option value="1760">Aruba 3800</option>
+<option value="1761">Cisco UCS 6500</option>
+<option value="1762">6th Generation Intel Core processor</option>
+<option value="1763">9th Generation Intel Core processor</option>
+<option value="1764">Intel JHL8440 Thunderbolt 4</option>
+<option value="1765">Juniper SRX300 Series</option>
+<option value="1766">Cisco UCS C-Series M5 Rack Server</option>
+<option value="1767">Cisco UCS C-Series M4 Rack Server</option>
+<option value="1768">Cisco UCS C-Series M6 Rack Server</option>
+<option value="1769">Cisco UCS C-Series M7 Rack Server</option>
+<option value="1770">Cisco UCS E-Series M2</option>
+<option value="1771">Cisco UCS E-Series M3</option>
+<option value="1772">IEC6400 Edge Compute Appliances</option>
+<option value="1773">Secure Endpoint Private Cloud Appliances</option>
+<option value="1774">Secure Malware Analytics Appliances</option>
+<option value="1775">Secure Network Analytics Appliances</option>
+<option value="1776">Secure Network Server Appliances</option>
+<option value="1777">Telemetry Broker Appliances</option>
+<option value="1778">LG43UM7000PLA</option>
+<option value="1779">OLED55CXPUA</option>
+<option value="1780">OLED48C1PUB</option>
+<option value="1781">OLED55A23LA</option>
+<option value="1782">UCS E-Series M6 Server</option>
+<option value="1783">Cisco UCS S-Series Storage Server</option>
+<option value="1784">Cisco Firepower 9000 Series</option>
+<option value="1786">Cisco Secure Firewall 3100 Series</option>
+<option value="1787">Cisco Secure Firewall 4200 Series</option>
+<option value="1788">Cisco Secure Firewall Threat Defense Virtual</option>
+<option value="1789">Secure Firewall Management Center Appliances</option>
+<option value="1790">Extreme Networks AP30</option>
+<option value="1791">Extreme Networks AP122</option>
+<option value="1792">Extreme Networks AP122X</option>
+<option value="1793">Extreme Networks AP130</option>
+<option value="1794">Extreme Networks AP150W</option>
+<option value="1795">Extreme Networks AP230</option>
+<option value="1796">Extreme Networks AP245X</option>
+<option value="1797">Extreme Networks AP250</option>
+<option value="1798">Extreme Networks AP550</option>
+<option value="1799">Extreme Networks AP1130</option>
+<option value="1800">dp4400</option>
+<option value="1801">dp5900</option>
+<option value="1802">dd3300</option>
+<option value="1803">dd6400</option>
+<option value="1804">dd6900</option>
+<option value="1805">dd9400</option>
+<option value="1806">dd9900</option>
+<option value="1807">OS X</option>
+<option value="1808">Ubuntu</option>
+<option value="1809">Windows 11</option>
+<option value="1810">Windows 7</option>
+<option value="1811">Catalyst 8500L Edge</option>
+<option value="1812">Intel Kaby Lake</option>
+<option value="1813">Intel Coffee Lake</option>
+<option value="1814">Intel Ice Lake</option>
+<option value="1815">Intel Comet Lake</option>
+<option value="1816">Intel Tiger Lake</option>
+<option value="1817">Intel Jasper Lake</option>
+<option value="1818">Intel Alder Lake</option>
+<option value="1819">Intel Raptor Lake</option>
+<option value="1820">Intel Meteor Lake</option>
+<option value="1821">IFM QHA300</option>
+<option value="1822">IFM QHA210</option>
+<option value="1823">IFM QVA200</option>
+<option value="1824">aarch64</option>
+<option value="1825">ppc64le</option>
+<option value="1828">ACX7000</option>
+<option value="1829">AdTran SRG 834-5</option>
+<option value="1830">Nuvoton NPCM750R</option>
+<option value="1831">Nuvoton NPCM710R</option>
+<option value="1832">Nuvoton NPCM730R</option>
+<option value="1833">Nuvoton NPCM705R</option>
+<option value="1834">NCS 1010 Series Routers</option>
+<option value="1835">NCS 1014 Series Routers</option>
+<option value="1836">Intel Sandy Bridge</option>
+<option value="1837">SOHO (Gen 5)</option>
+<option value="1838">SM9800</option>
+<option value="1839">NSsp 12400</option>
+<option value="1840">NSsp 12800</option>
+<option value="1841">Fplus T1100</option>
+<option value="1842">Fplus T800</option>
+<option value="1844">HP 14-cf2xxx</option>
+<option value="1845">HP 14t-cf200</option>
+<option value="1846">HP 14-cf3xxx</option>
+<option value="1847">HP 14t-cf300</option>
+<option value="1848">HP 14-dq0xxx</option>
+<option value="1849">HP 14t-dq000</option>
+<option value="1850">HP 14-dq1xxx</option>
+<option value="1851">HP 14t-dq100</option>
+<option value="1852">HP 14-dq2xxx</option>
+<option value="1853">HP 14t-dq200</option>
+<option value="1854">HP 14-dq3xxx</option>
+<option value="1855">HP 14t-dq300</option>
+<option value="1856">HP 14-dq4xxx</option>
+<option value="1857">HP 14t-dq400</option>
+<option value="1858">HP 14-dq5xxx</option>
+<option value="1859">HP 14t-dq500</option>
+<option value="1860">HP 14-ee0xxx</option>
+<option value="1861">HP 14-em0xxx</option>
+<option value="1862">HP 14-ep0xxx</option>
+<option value="1863">HP 14-ep1xxx</option>
+<option value="1864">HP 14-gr0xxx</option>
+<option value="1865">HP 14-gr1xxx</option>
+<option value="1866">HP 14-hr0xxx</option>
+<option value="1867">HP 14-ma2xxx</option>
+<option value="1868">HP 14t-ma200</option>
+<option value="1869">HP 14-ma3xxx</option>
+<option value="1870">HP 14t-ma300</option>
+<option value="1871">HP 14s-cf2xxx</option>
+<option value="1872">HP 14s-cf3xxx</option>
+<option value="1873">HP 14s-cr2xxx</option>
+<option value="1874">HP 14s-cr3xxx</option>
+<option value="1875">HP 14s-cs2xxx</option>
+<option value="1876">HP 14s-cs3xxx</option>
+<option value="1877">HP 14s-dq0xxx</option>
+<option value="1878">HP 14s-dq1xxx</option>
+<option value="1879">HP 14s-dq2xxx</option>
+<option value="1880">HP 14s-dq3xxx</option>
+<option value="1881">HP 14s-dq4xxx</option>
+<option value="1882">HP 14s-dq5xxx</option>
+<option value="1883">HP 14s-dr0xxx</option>
+<option value="1884">HP 14s-dr1xxx</option>
+<option value="1885">HP 14s-dr2xxx</option>
+<option value="1886">HP 14s-dr3xxx</option>
+<option value="1887">HP 14s-dr4xxx</option>
+<option value="1888">HP 14s-dr5xxx</option>
+<option value="1889">HP 14s-dy0xxx</option>
+<option value="1890">HP 14s-dy1xxx</option>
+<option value="1891">HP 14s-dy2xxx</option>
+<option value="1892">HP 14s-dy3xxx</option>
+<option value="1893">HP 14s-dy4xxx</option>
+<option value="1894">HP 14s-dy5xxx</option>
+<option value="1895">HP 15-dy0xxx</option>
+<option value="1896">HP 15t-dy000</option>
+<option value="1897">HP 15-dy1xxx</option>
+<option value="1898">HP 15t-dy100</option>
+<option value="1899">HP 15-dy2xxx</option>
+<option value="1901">HP 15t-dy200</option>
+<option value="1902">HP 15-dy3xxx</option>
+<option value="1903">HP 15t-dy300</option>
+<option value="1904">HP 15-dy4xxx</option>
+<option value="1905">HP 15t-dy400</option>
+<option value="1906">HP 15-dy5xxx</option>
+<option value="1907">HP 15t-dy500</option>
+<option value="1908">HP 15-ef0xxx</option>
+<option value="1909">HP 15z-ef000</option>
+<option value="1910">HP 15-ef1xxx</option>
+<option value="1911">HP 15z-ef100</option>
+<option value="1912">HP 15-ef2xxx</option>
+<option value="1913">HP 15z-ef200</option>
+<option value="1914">HP 15-ef3xxx</option>
+<option value="1916">HP 15z-ef300</option>
+<option value="1917">HP 15-fc0xxx</option>
+<option value="1918">HP 15-fc1xxx</option>
+<option value="1919">HP 15-fd0xxx</option>
+<option value="1920">HP 15-fd1xxx</option>
+<option value="1921">HP 15-gw0xxx</option>
+<option value="1922">HP 15-hr0xxx</option>
+<option value="1923">HP 15-hr1xxx</option>
+<option value="1924">HP 15-kr0xxx</option>
+<option value="1925">HP 15-kr1xxx</option>
+<option value="1926">HP 15s-eq0xxx</option>
+<option value="1927">HP 15s-eq1xxx</option>
+<option value="1928">Node.js</option>
+<option value="1929">HP 15s-eq2xxx</option>
+<option value="1930">HP 15s-eq3xxx</option>
+<option value="1931">HP 15s-er0xxx</option>
+<option value="1932">HP 15s-er1xxx</option>
+<option value="1933">HP 15s-er2xxx</option>
+<option value="1934">HP 15s-er3xxx</option>
+<option value="1935">HP 15s-ey0xxx</option>
+<option value="1936">HP 15s-ey1xxx</option>
+<option value="1937">HP 15s-ey2xxx</option>
+<option value="1938">HP 15s-ey3xxx</option>
+<option value="1939">HP 15s-fq0xxx</option>
+<option value="1940">HP 15s-fq1xxx</option>
+<option value="1941">HP 15s-fq2xxx</option>
+<option value="1942">HP 15s-fq3xxx</option>
+<option value="1943">HP 15s-fq4xxx</option>
+<option value="1944">HP 15s-fq5xxx</option>
+<option value="1945">HP 15s-fr0xxx</option>
+<option value="1946">HP 15s-fr1xxx</option>
+<option value="1947">HP 15s-fr2xxx</option>
+<option value="1948">HP 15s-fr3xxx</option>
+<option value="1949">HP 15s-fr4xxx</option>
+<option value="1950">HP 15s-fr5xxx</option>
+<option value="1951">HP 15s-fy0xxx</option>
+<option value="1952">HP 15s-fy1xxx</option>
+<option value="1953">HP 15s-fy2xxx</option>
+<option value="1954">HP 15s-fy3xxx</option>
+<option value="1955">HP 15s-fy4xxx</option>
+<option value="1956">HP 15s-fy5xxx</option>
+<option value="1957">HP 15s-gr0xxx</option>
+<option value="1958">HP 15s-gu0xxx</option>
+<option value="1959">HP 15s-gy0xxx</option>
+<option value="1960">HP 17-cn1xxx</option>
+<option value="1961">HP 17t-cn100</option>
+<option value="1962">HP 17-cn2xxx</option>
+<option value="1963">HP 17t-cn200</option>
+<option value="1964">HP 17-cn3xxx</option>
+<option value="1965">HP 17-cn4xxx</option>
+<option value="1966">HP 17-cp0xxx</option>
+<option value="1967">HP 17z-cp000</option>
+<option value="1968">HP 17-cp1xxx</option>
+<option value="1969">HP 17z-cp100</option>
+<option value="1970">HP 17-cp2xxx</option>
+<option value="1971">HP 17-cp3xxx</option>
+<option value="1972">HP 17s-cr2xxx</option>
+<option value="1973">HP 17s-cr3xxx</option>
+<option value="1974">HP 17s-cr4xxx</option>
+<option value="1975">HP 17s-cu2xxx</option>
+<option value="1976">HP 17s-cu3xxx</option>
+<option value="1977">HP 17s-cy2xxx</option>
+<option value="1978">HP 17s-cy3xxx</option>
+<option value="1979">HP Envy 16-h0xxx</option>
+<option value="1980">HP 16t-h000</option>
+<option value="1981">HP Envy 16-h1xxx</option>
+<option value="1982">HP Envy 17-cr0xxx</option>
+<option value="1983">HP 17t-cr000</option>
+<option value="1984">HP Envy 17-cr1xxx</option>
+<option value="1985">HP Envy 17-cw0xxx</option>
+<option value="1986">HP Envy 17-cw1xxx</option>
+<option value="1987">HP Envy x360 13-bf0xxx</option>
+<option value="1988">HP Envy x360 13t-bf000</option>
+<option value="1989">HP Envy x360 14-es0xxx</option>
+<option value="1990">HP Envy x360 14-es1xxx</option>
+<option value="1991">HP Envy x360 15-eu0xxx</option>
+<option value="1992">HP Envy x360 15z-eu000</option>
+<option value="1993">HP Envy x360 15-ew0xxx</option>
+<option value="1994">HP Envy x360 15t-ew000</option>
+<option value="1995">HP Envy x360 15-ew1xxx</option>
+<option value="1996">HP Envy x360 15-ey0xxx</option>
+<option value="1997">HP Envy x360 15t-ey000</option>
+<option value="1998">HP Envy x360 15-ey1xxx</option>
+<option value="1999">HP Envy x360 15-fe0xxx</option>
+<option value="2000">HP Envy x360 15-fe1xxx</option>
+<option value="2001">HP Envy x360 15-fh0xxx</option>
+<option value="2002">HP Envy x360 15m-eu0xxx</option>
+<option value="2003">HP Pavilion 13-be0xxx</option>
+<option value="2004">HP Pavilion13z-be000</option>
+<option value="2005">HP Pavilion 15-eg0xxx</option>
+<option value="2006">HP Pavilion 15t-eg000</option>
+<option value="2007">HP Pavilion 15-eg1xxx</option>
+<option value="2008">HP Pavilion 15t-eg100</option>
+<option value="2009">HP Pavilion 15-eg2xxx</option>
+<option value="2010">HP Pavilion 15t-eg200</option>
+<option value="2011">HP Pavilion 15-eg3xxx</option>
+<option value="2012">HP Pavilion 15-eh0xxx</option>
+<option value="2013">HP Pavilion 15z-eh000</option>
+<option value="2014">HP Pavilion 15-eh1xxx</option>
+<option value="2015">HP Pavilion 15-eh2xxx</option>
+<option value="2016">HP Pavilion 15z-eh200</option>
+<option value="2017">HP Pavilion 15-eh3xxx</option>
+<option value="2018">HP Pavilion Aero 13-be1xxx</option>
+<option value="2019">HP Pavilion Aero 13z-be100</option>
+<option value="2020">HP Pavilion Aero 13-be2xxx</option>
+<option value="2021">HP Pavilion Plus 14-ew0xxx</option>
+<option value="2022">HP Pavilion Plus 14-ew1xxx</option>
+<option value="2023">HP Pavilion Plus 14-ey0xxx</option>
+<option value="2024">HP Pavilion Plus 14-ey1xxx</option>
+<option value="2025">HP Pavilion Plus 16-ab0xxx</option>
+<option value="2026">HP Pavilion Plus 16-ab1xxx</option>
+<option value="2027">HP Pavilion x360 14-ek0xxx</option>
+<option value="2028">HP Pavilion x360 14t-ek000</option>
+<option value="2029">HP Pavilion x360 14-ek1xxx</option>
+<option value="2030">HP Pavilion x360 14-ek2xxx</option>
+<option value="2031">HP Pavilion x360 15-er0xxx</option>
+<option value="2032">HP Pavilion x360 15t-er000</option>
+<option value="2033">HP Pavilion x360 15-er1xxx</option>
+<option value="2034">HP Pavilion x360 15t-er100</option>
+<option value="2035">HP Spectre x360 13-aw0xxx</option>
+<option value="2036">HP Spectre x360 14-eu0xxx</option>
+<option value="2037">HP Spectre x360 16-aa0xxx</option>
+<option value="2038">OMEN Gaming Laptop 15-fa0xxx</option>
+<option value="2039">OMEN Gaming Laptop 15t-fa000</option>
+<option value="2040">OMEN Gaming Laptop 16-wd0xxx</option>
+<option value="2041">OMEN Gaming Laptop 16-wf0xxx</option>
+<option value="2042">OMEN Gaming Laptop 16-wf1xxx</option>
+<option value="2043">OMEN Gaming Laptop 16-xd0xxx</option>
+<option value="2044">OMEN Gaming Laptop 16-xf0xxx</option>
+<option value="2045">OMEN Gaming Laptop 17-ck0xxx</option>
+<option value="2046">OMEN Gaming Laptop 17t-ck100</option>
+<option value="2047">OMEN Gaming Laptop 17-ck1xxx</option>
+<option value="2048">OMEN Gaming Laptop 17-ck2xxx</option>
+<option value="2049">OMEN Gaming Laptop 17-cm2xxx</option>
+<option value="2050">OMEN Transcend Gaming Laptop 16-u0xxx</option>
+<option value="2051">OMEN Transcend Gaming Laptop 16-u1xxx</option>
+<option value="2052">Victus Gaming Laptop 15-fa1xxx</option>
+<option value="2053">Victus Gaming Laptop 15-fb0xxx</option>
+<option value="2054">Victus Gaming Laptop 15z-fb000</option>
+<option value="2055">Victus Gaming Laptop 15-fb1xxx</option>
+<option value="2056">Victus Gaming Laptop 15-fb2xxx</option>
+<option value="2057">Victus Gaming Laptop 16-r0xxx</option>
+<option value="2058">Victus Gaming Laptop 16-r1xxx</option>
+<option value="2059">Victus Gaming Laptop 16-s0xxx</option>
+<option value="2060">Victus Gaming Laptop 16-s1xxx</option>
+<option value="2061">HP 240 G10 Notebook PC</option>
+<option value="2062">HP 240 G8 Notebook PC</option>
+<option value="2063">HP 240 G9 Notebook PC</option>
+<option value="2064">HP 240R G9 Notebook PC</option>
+<option value="2065">HP 245 G10 Notebook PC</option>
+<option value="2066">HP 250 G10 Notebook PC</option>
+<option value="2067">HP 250 G9 Notebook PC</option>
+<option value="2068">HP 255 G10 Notebook PC</option>
+<option value="2069">HP 255 G8 Notebook PC</option>
+<option value="2070">HP 255 G9 Notebook PC</option>
+<option value="2071">HP 340S G7 Notebook PC</option>
+<option value="2072">HP 350S G7 Notebook PC</option>
+<option value="2073">HP 470 G10 Notebook PC</option>
+<option value="2074">HP 470 G8 Notebook PC</option>
+<option value="2075">HP 470 G9 Notebook PC</option>
+<option value="2076">HP ZHAN 14 inch G6 Notebook PC</option>
+<option value="2077">HP ZHAN A 14 inch G6 Notebook PC</option>
+<option value="2078">HP ZHAN 14 inch G7 Notebook PC</option>
+<option value="2079">HP All-in-One Desktop 24-cr0xxxa</option>
+<option value="2080">HP Pavilion All-in-One 32-b0xxxi</option>
+<option value="2081">HP ProOne 240 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2082">HP ProOne 245 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2083">HP ZHAN 66 Pro A 23.8 inch G10 All-in-One Desktop PC</option>
+<option value="2084">NCS 540-24Q8L2DD-SYS Router</option>
+<option value="2085">NCS 540-24Z8Q2C-SYS Router</option>
+<option value="2086">NCS 540-28Z4C-SYS-A Router</option>
+<option value="2087">NCS 540-28Z4C-SYS-D Router</option>
+<option value="2088">NCS 540-ACC-SYS Router</option>
+<option value="2089">NCS 540X-16Z4G8Q2C-A Router</option>
+<option value="2090">NCS 540X-16Z4G8Q2C-D Router</option>
+<option value="2091">NCS 55A1-24Q6H-SS</option>
+<option value="2092">NCS 55A2-MOD-SE-S</option>
+<option value="2093">NCS-57C1-48Q6-SYS</option>
+<option value="2094">NCS 57C3-MOD</option>
+<option value="2095">Aruba 100 Series Access Points</option>
+<option value="2096">Aruba 103 Series Access Points</option>
+<option value="2097">Aruba 110 Series Access Points</option>
+<option value="2098">Aruba 120 Series Access Points</option>
+<option value="2099">Aruba 130 Series Access Points</option>
+<option value="2100">Aruba 200 Series Access Points</option>
+<option value="2101">Aruba 207 Series Access Points</option>
+<option value="2102">Aruba 210 Series Access Points</option>
+<option value="2103">Aruba 220 Series Access Points</option>
+<option value="2104">Aruba 260 Series Access Points</option>
+<option value="2105">Aruba 300 Series Access Points</option>
+<option value="2106">Aruba 303 Series Access Points</option>
+<option value="2107">Aruba 310 Series Access Points</option>
+<option value="2108">Aruba 320 Series Access Points</option>
+<option value="2109">Aruba 330 Series Access Points</option>
+<option value="2110">Aruba 340 Series Access Points</option>
+<option value="2111">Aruba 370 Series Access Points</option>
+<option value="2112">Aruba 500 Series Access Points</option>
+<option value="2113">Aruba 510 Series Access Points</option>
+<option value="2114">Aruba 530 Series Access Points</option>
+<option value="2115">Aruba 550 Series Access Points</option>
+<option value="2116">Aruba 630 Series Access Points</option>
+<option value="2117">Aruba 650 Series Access Points</option>
+<option value="2118">ASR9K-X64</option>
+<option value="2120">NCS 540L</option>
+<option value="2121">MX304 Series</option>
+<option value="2122">SRX5K</option>
+<option value="2123">S/390</option>
+<option value="2125">Catalyst 9300LM Series Switches</option>
+<option value="2126">Catalyst 9300X Series Switches</option>
+<option value="2127">Catalyst 9400X Supervisor Engines</option>
+<option value="2128">Catalyst 9500 High Performance Series Switches</option>
+<option value="2130">Harmony Industrial PC HMIBMO series</option>
+<option value="2131">Harmony Industrial PC HMIBMI series</option>
+<option value="2132">Harmony Industrial PC HMIPSO series</option>
+<option value="2133">Harmony Industrial PC HMIBMP series</option>
+<option value="2134">Harmony Industrial PC HMIBMU series</option>
+<option value="2135">Harmony Industrial PC HMIPSP series</option>
+<option value="2136">Harmony Industrial PC HMIPEP series</option>
+<option value="2137">Pro-face Industrial PC PS5000 series</option>
+<option value="2138">virtio-snd</option>
+<option value="2139">PA-800 Series</option>
+<option value="2145">UCS C-Series Servers in UCS Manager Mode</option>
+<option value="2146">UCS B-Series Servers in UCS Manager Mode</option>
+<option value="2147">UCS B-Series Servers in Intersight Management Mode</option>
+<option value="2148">UCS C-Series Servers in Intersight Management Mode</option>
+<option value="2149">UCS X-Series Servers in Intersight Management Mode</option>
+<option value="2150">UCS X-Series Servers in UCS Manager Mode</option>
+<option value="2151">PA-3200 Series</option>
+<option value="2152">PA-5200 Series</option>
+<option value="2153">PA-7000 Series</option>
+<option value="2154">Intel-based Mac systems</option>
+<option value="2155">11th Generation Intel Core Processor</option>
+<option value="2156">12th Generation Intel Core Processor</option>
+<option value="2157">Intel NUC M15 LAPRC710</option>
+<option value="2158">Intel NUC M15 LAPRC510</option>
+<option value="2159">Brocade 7810</option>
+<option value="2160">Brocade 7840</option>
+<option value="2161">Brocade 7850</option>
+<option value="2162">Brocade X6</option>
+<option value="2163">Brocade X7</option>
+<option value="2164">«Новая программно-аппаратная платформа»</option>
+<option value="2165">W461AS-EG</option>
+<option value="2166">W462AQ-EG</option>
+<option value="2167">W461AS</option>
+<option value="2168">W462AQ</option>
+<option value="2169">W461AS-EG S2</option>
+<option value="2170">W462AC-EG S2</option>
+<option value="2171">W461ASC</option>
+<option value="2172">TZ80</option>
+<option value="2173">RoomOS</option>
+<option value="2174">amd64</option>
+<option value="2175">AIX</option>
+<option value="2176">PowerStore 500T</option>
+<option value="2177">PowerStore 1000T</option>
+<option value="2178">PowerStore 1200T</option>
+<option value="2179">PowerStore 3000T</option>
+<option value="2180">PowerStore 3200T</option>
+<option value="2181">PowerStore 5000T</option>
+<option value="2182">PowerStore 5200T</option>
+<option value="2183">PowerStore 7000T</option>
+<option value="2184">PowerStore 9000T</option>
+<option value="2185">PowerStore 9200T</option>
+<option value="2186">Schneider Electric BMXNOR0200H</option>
+<option value="2187">Schneider Electric BMXNOE0110(H)</option>
+<option value="2188">Schneider Electric BMENOC0311(C)</option>
+<option value="2189">Schneider Electric BMENOC0321</option>
+<option value="2190">MPX</option>
+<option value="2191">PT MC</option>
+<option value="2192">Secure Endpoint Connector</option>
+<option value="2193">watsonx</option>
+<option value="2194">IBM Watsonx</option>
+<option value="2195">Spring Framework</option>
+<option value="2196">P550</option>
+<option value="2197">Azure Local</option>
+<option value="2198">R81</option>
+<option value="2199">R80</option>
+<option value="2200">R77</option>
+<option value="2201">R75</option>
+<option value="2202">710 Series</option>
+<option value="2203">720D Series</option>
+<option value="2204">720XP Series</option>
+<option value="2205">722XPM Series</option>
+<option value="2206">750X Series</option>
+<option value="2207">7010 Series</option>
+<option value="2208">7010X Series</option>
+<option value="2209">7020R Series</option>
+<option value="2210">7130 Series</option>
+<option value="2211">7150 Series</option>
+<option value="2212">7160 Series</option>
+<option value="2213">7170 Series</option>
+<option value="2214">7050X Series</option>
+<option value="2215">7050X2 Series</option>
+<option value="2216">7050X3 Series</option>
+<option value="2217">7050X4 Series</option>
+<option value="2218">7060X Series</option>
+<option value="2219">7060X2 Series</option>
+<option value="2220">7060X4 Series</option>
+<option value="2221">7060X5 Series</option>
+<option value="2222">7060X6 Series</option>
+<option value="2223">7250X Series</option>
+<option value="2224">7260X Series</option>
+<option value="2225">7260X3 Series</option>
+<option value="2226">7280E Series</option>
+<option value="2227">7280R Series</option>
+<option value="2228">7280R2 Series</option>
+<option value="2229">7280R3 Series</option>
+<option value="2230">7300X Series</option>
+<option value="2231">7300X3 Series</option>
+<option value="2232">7320X Series</option>
+<option value="2233">7358X4 Series</option>
+<option value="2234">7368X4 Series</option>
+<option value="2235">7388X5 Series</option>
+<option value="2236">7500E Series</option>
+<option value="2237">7500R Series</option>
+<option value="2238">7500R2 Series</option>
+<option value="2239">7500R3 Series</option>
+<option value="2240">7800R3 Series</option>
+<option value="2241">7800R4 Series</option>
+<option value="2242">7700R4 Series</option>
+<option value="2243">AWE 5000 Series</option>
+<option value="2244">AWE 7200R Series</option>
+<option value="2245">CloudEOS</option>
+<option value="2246">cEOS-lab</option>
+<option value="2247">vEOS-lab</option>
+<option value="2248">NCS 1004</option>
+<option value="2249">ASR 9000 Series Aggregation Services Routers (64-bit)</option>
+<option value="2250">8608 Routers</option>
+<option value="2251">8804 Routers</option>
+<option value="2252">8808 Routers</option>
+<option value="2253">8812 Routers</option>
+<option value="2254">8818 Routers</option>
+<option value="2255">NCS S5504</option>
+<option value="2256">NCS S5508</option>
+<option value="2257">NCS S5516</option>
+<option value="2258">1С-Битрикс</option>
+<option value="2259">1С-Битрикс: Управление сайтом</option>
+<option value="2260">IBM AIX</option>
+<option value="2261">IBM i</option>
+<option value="2262">IBM PowerLinux</option>
+<option value="2263">DSM 3.1</option>
+<option value="2264">DSM 7.2</option>
+<option value="2265">DSM 7.1</option>
+<option value="2266">DSM 6.2</option>
+<option value="2267">DSM 7.2.1</option>
+<option value="2268">DSM 7.2.2</option>
+<option value="2269">AS3000Simulator</option>
+<option value="2270">EX4650-48Y</option>
+<option value="2271">до версии 9 включительно</option>
+<option value="2273">--</option>
+<option value="2274">---</option>
+<option value="2275">Google Chrome</option>
+<option value="2276">Microsoft Edge</option>
+<option value="2277">Windows Desktop</option>
+<option value="2278">FortiGate 200F</option>
+<option value="2279">PowerStore 3200Q</option>
+<option value="2280">MediaTek MT6890</option>
+<option value="2281">MediaTek MT6990</option>
+<option value="2282">UCS C-Series M5</option>
+<option value="2283">SRX1600</option>
+<option value="2284">SRX2300</option>
+<option value="2285">C300 PCNT02</option>
+<option value="2286">EHB</option>
+<option value="2287">EHPM</option>
+<option value="2288">ELMM</option>
+<option value="2289">Classic ENIM</option>
+<option value="2290">ETN</option>
+<option value="2291">FIM4</option>
+<option value="2292">FIM8</option>
+<option value="2293">PGM</option>
+<option value="2294">RFIM</option>
+<option value="2295">arm64-SBSA</option>
+<option value="2296">x86_64</option>
+<option value="2297">x86</option>
+<option value="2298">Jetson Linux</option>
+<option value="2299">IGX OS</option>
+<option value="2300">NSV270</option>
+<option value="2301">NSv470</option>
+<option value="2302">NSv870</option>
+<option value="2303">«Бизнес»</option>
+<option value="2304">в редакции «Бизнес»</option>
+<option value="2305">в редакции «Корпорация»</option>
+<option value="2306">в редакции «Корпорация +»</option>
+<option value="2307">в редакции «Корпорация + ФСТЭК»</option>
+<option value="2308">Windows 10 IoT Enterprise LTSC 2021</option>
+<option value="2309">Windows 11 IoT Enterprise LTSC 2024</option>
+<option value="2310">Windows 11 Professional 2022</option>
+<option value="2311">Windows 10 Enterprise LTSC 21H2</option>
+<option value="2312">Windows 10 IoT Enterprise LTSC 2019</option>
+<option value="2313">Windows 10 IoT Enterprise LTSC 2021 for DN-PRP-HSR-I210 module</option>
+<option value="2314">Serial Interface and IO Controller</option>
+<option value="2315">Windows 10 IoT Enterprise LTSC 2021 for DE-PRP-HSR-EF module</option>
+<option value="2316">SerialInterface for Windows 10</option>
+<option value="2317">Windows 10 IoT Enterprise LTSC 2019/2021 for DE-2-IRIGB-4-DI/DO module</option>
+<option value="2318">Windows Server 2022</option>
+<option value="2319">Windows Server 2022 for expansion modules</option>
+<option value="2320">Windows 10 IoT Enterprise LTSC 2019 and Windows Server 2019</option>
+<option value="2321">DN-PRP-HSR-I210 module</option>
+<option value="2322">Windows 10 IoT Enterprise LTSC 2021 for DA-PRP-HSR-I210 module</option>
+<option value="2323">Windows 11 IoT Enterprise LTSC 2024 for Expansion Modules</option>
+<option value="2324">Windows 10 IoT Enterprise LTSC 2021 for Expansion Modules</option>
+<option value="2325">Tools for Windows Embedded Standard 7</option>
+<option value="2326">Windows 7 Embedded</option>
+<option value="2327">Windows 11 Enterprise LTSC 24H2</option>
+<option value="2328">Windows 11 Professional 2023</option>
+<option value="2329">SerialInterface</option>
+<option value="2330">MxOSD</option>
+<option value="2331">BlueField-2</option>
+<option value="2332">BlueField-3</option>
+<option value="2333">IOS XR White box (IOSXRWBD)</option>
+<option value="2334">NCS 560 Series Routers</option>
+<option value="2335">NCS 1000 Series</option>
+<option value="2336">NCS 1001 Series</option>
+<option value="2337">NCS 1002 Series</option>
+<option value="2338">NCS 1004 Series</option>
+<option value="2339">NCS 5000 Series Routers</option>
+<option value="2340">NCS 5500 Series Routers</option>
+<option value="2341">NCS 6000 Series Routers</option>
+<option value="2342">IOS XRd vRouters</option>
+<option value="2343">IOS XRv 9000 Routers</option>
+<option value="2344">Network Convergence Series (NCS) 540 Series Routers</option>
+<option value="2345">NCS 1010 Platforms</option>
+<option value="2346">NCS 1014 Platforms</option>
+<option value="2347">Dell Pro Rugged 13 RA13250</option>
+<option value="2348">Dell Pro Rugged 14 RB14250</option>
+<option value="2349">Latitude 5350</option>
+<option value="2350">Latitude 5450</option>
+<option value="2351">Latitude 5550</option>
+<option value="2352">Latitude 7030 Rugged Extreme Tablet</option>
+<option value="2353">Latitude 7350</option>
+<option value="2354">Latitude 7350 Detachable</option>
+<option value="2355">Latitude 7450</option>
+<option value="2356">Latitude 7650</option>
+<option value="2357">Latitude 9450 2-in-1</option>
+<option value="2358">Mobile Precision 3591</option>
+<option value="2359">Precision 3490</option>
+<option value="2360">Precision 3590</option>
+<option value="2361">User interface Tag</option>
+<option value="2362">Backend Tag</option>
+<option value="2363">UWP</option>
+<option value="2364">Desk Phone 9800 Series</option>
+<option value="2365">Cisco Video Phone 8875</option>
+<option value="2366">Global Android 13</option>
+<option value="2367">China Android 13</option>
+<option value="2368">Android 14</option>
+<option value="2369">Java</option>
+<option value="2370">SRX4700</option>
+<option value="2371">Azure Stack Hub</option>
+<option value="2372">XenServer</option>
+<option value="2373">Mediatek MT9972</option>
+<option value="2374">Mediatek МТ7915</option>
+<option value="2375">Mediatek MT7916</option>
+<option value="2376">Mediatek MT7981</option>
+<option value="2377">Mediatek MT7986</option>
+<option value="2378">TZ280</option>
+<option value="2379">TZ380</option>
+<option value="2380">TZ480</option>
+<option value="2381">TZ580</option>
+<option value="2382">TZ680</option>
+<option value="2383">NSa 2800</option>
+<option value="2384">NSa 3800</option>
+<option value="2385">NSa 4800</option>
+<option value="2386">NSa 5800</option>
+<option value="2387">ESX</option>
+<option value="2388">KVM</option>
+<option value="2389">HYPER-V</option>
+<option value="2390">AWS</option>
+<option value="2391">Azure</option>
+<option value="2392">MT7990</option>
+<option value="2393">Mediatek MT7990</option>
+<option value="2394">Mediatek MT7992</option>
+<option value="2395">ES Appliance 5000</option>
+<option value="2396">ES Appliance 5050</option>
+<option value="2397">ES Appliance 7000</option>
+<option value="2398">ES Appliance 7050</option>
+<option value="2399">ES Appliance 9000</option>
+<option value="2400">VMWare</option>
+<option value="2401">NVIDIA DGX OS</option>
+<option value="2402">0x95</option>
+<option value="2403">0x20</option>
+<option value="2404">0x01</option>
+<option value="2405">Z3</option>
+<option value="2406">Z4</option>
+<option value="2407">Z4C</option>
+<option value="2408">Z3C</option>
+<option value="2409">Meraki MX65</option>
+<option value="2410">Meraki MX65W</option>
+<option value="2411">Meraki MX75</option>
+<option value="2412">Meraki MX85</option>
+<option value="2413">Meraki MX95</option>
+<option value="2414">Meraki MX105</option>
+<option value="2415">Meraki MX400</option>
+<option value="2416">Meraki MX600</option>
+<option value="2417">Frontend административной части</option>
+<option value="2418">Frontend ученической части</option>
+<option value="2419">Backend</option>
+<option value="2420">FreeBSD</option>
+<option value="2421">TCIV</option>
+<option value="2422">for Python</option>
+<option value="2423">XR1000v2</option>
+<option value="2424">Astra Linux Special Edition 1.7</option>
+<option value="2425">Astra Linux Special Edition 1.8</option>
+<option value="2426">РЕД ОС 7.3</option>
+<option value="2427">Platform V SberLinux OS 8</option>
+<option value="2428">Platform V SberLinux OS 9</option>
+<option value="2429">Эльбрус</option>
+<option value="2430">от 4.6 до 4.9.336 включительно</option>
+<option value="2431">GB200</option>
+<option value="2432">GB300 (1.0)</option>
+<option value="2433">IBSwitch XDR</option>
+</select>    <div class="errorMessage" id="VulFilterForm_platf_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_version">Версия ПО</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                          data-toggle="popover"
+                                                          data-content="Версия программного обеспечения, в которой обнаружена уязвимость, или программное обеспечение, подверженное уязвимости.<br/>
+                                                          Возможно использование следующих форматов:<br/>
+                            1) <b><i>«версия»</i></b> <small>– поиск уязвимостей, включающих введеную версию</small><br/>
+                            2) <b>от <i>«версия»</i></b> <small>или</small> <b><i>«версия» -</i></b> <small>– поиск уязвимостей, входящих в диапазон [<i>«версия»</i>;...]</small><br/>
+                            3) <b>до <i>«версия»</i></b> <small>или</small> <b><i>- «версия»</i></b> <small>– поиск уязвимостей, входящих в диапазон [...;<i>«версия»</i>]</small><br/>
+                            4) <b>от <i>«версия_1»</i> до <i>«версия_2»</i></b> <small>или</small> <b><i>«версия_1»</i> - <i>«версия_2»</i></b> <small>– поиск уязвимостей, входящих в диапазон [<i>«версия_1»</i>;<i>«версия_2»</i>]</small><br/>
+                            "></span>
+    <input name="VulFilterForm[version]" id="VulFilterForm_version" type="hidden" />    <div class="errorMessage" id="VulFilterForm_version_em_" style="display:none"></div></div>
+
+<div class="form-group">
+    <label for="VulFilterForm_vul_state">Статус уязвимости</label>    <span class="glyphicon glyphicon-question-sign help-hint"
+                                                               data-toggle="popover"
+                                                               data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/50">Статус уязвимости</a> программного обеспечения'></span>
+    <select name="VulFilterForm[vul_state]" id="VulFilterForm_vul_state">
+<option value=""></option>
+<option value="0">Потенциальная уязвимость</option>
+<option value="1">Подтверждена производителем</option>
+<option value="2">Подтверждена в ходе исследований</option>
+</select>    <div class="errorMessage" id="VulFilterForm_vul_state_em_" style="display:none"></div></div>
+
+<div class="spoiler-btn">
+    <span class="glyphicon glyphicon-chevron-down"></span>Доп. параметры
+</div>
+
+<div class="spoiler">
+    <div class="spoiler-body in">
+        <div class="form-group">
+            <label for="VulFilterForm_dateRange">Диапазон дат</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                    data-toggle="popover"
+                                                                    data-content="Диапазон дат выявления уязвимостей"></span>
+            <div class="row">
+                <div class="col-sm-6 col-xs-6">
+                    <div class="input-group">
+                        <span class="input-group-addon">c</span>
+                        <input class="form-control input-sm" name="VulFilterForm[fromDate]" id="VulFilterForm_fromDate" type="text" />                    </div>
+                </div>
+                <div class="col-sm-6 col-xs-6">
+                    <div class="input-group">
+                        <span class="input-group-addon">по</span>
+                        <input class="form-control input-sm" name="VulFilterForm[toDate]" id="VulFilterForm_toDate" type="text" />                    </div>
+                </div>
+            </div>
+            <div class="errorMessage" id="VulFilterForm_toDate_em_" style="display:none"></div>        </div>
+                <!--        -->        <div class="form-group">
+            <input id="ytVulFilterForm_vul_incident" type="hidden" value="0" name="VulFilterForm[vul_incident]" /><input name="VulFilterForm[vul_incident]" id="VulFilterForm_vul_incident" value="1" type="checkbox" />            <label for="VulFilterForm_vul_incident">Уязвимости, связанные с инцидентами ИБ</label>            <span class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                  data-content='Показать только уязвимости программного обеспечения, связанные с инцидентами информационной безопасности'></span>
+            <div class="errorMessage" id="VulFilterForm_vul_incident_em_" style="display:none"></div>        </div>
+        <div class="form-group">
+            <input id="ytVulFilterForm_vul_extended_desc" type="hidden" value="0" name="VulFilterForm[vul_extended_desc]" /><input name="VulFilterForm[vul_extended_desc]" id="VulFilterForm_vul_extended_desc" value="1" type="checkbox" />            <label for="VulFilterForm_vul_extended_desc">Доступно расширенное описание</label>            <span class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                  data-content='Доступна информация, уточняющая описание уязвимости относительно каждого наименования уязвимого программного обеспечения'></span>
+            <div class="errorMessage" id="VulFilterForm_vul_extended_desc_em_" style="display:none"></div>        </div>
+        <div class="form-group">
+            <label for="VulFilterForm_yearAdd">Год добавления</label><span
+                    class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                    data-content='Год добавления записей об уязвимостях в Банк данных'></span>
+            <input empty="2026" name="VulFilterForm[yearAdd]" id="VulFilterForm_yearAdd" type="hidden" />            <div class="errorMessage" id="VulFilterForm_yearAdd_em_" style="display:none"></div>        </div>
+        <!--        -->        <div class="form-group">
+            <label for="VulFilterForm_clvul">Класс уязвимости</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                data-toggle="popover"
+                                                                data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/26">Класс уязвимости</a>, обнаруженной в программном обеспечении'></span>
+            <select name="VulFilterForm[clvul]" id="VulFilterForm_clvul">
+<option value=""></option>
+<option value="1">Уязвимость кода</option>
+<option value="3">Уязвимость архитектуры</option>
+<option value="6">Уязвимость многофакторная</option>
+</select>            <div class="errorMessage" id="VulFilterForm_clvul_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_bsLevel">Уровень опасности</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                  data-toggle="popover"
+                                                                  data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/56">Уровень опасности</a> обнаруженной уязвимости'></span>
+            <select name="VulFilterForm[bsLevel]" id="VulFilterForm_bsLevel">
+<option value=""></option>
+<option value="1">Низкий</option>
+<option value="2">Средний</option>
+<option value="3">Высокий</option>
+<option value="4">Критический</option>
+</select>            <div class="errorMessage" id="VulFilterForm_bsLevel_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_bsCVSS">Базовый вектор</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                 data-toggle="popover"
+                                                                 data-content='<a target="_blank" rel="noopener noreferrer" href="/ubi/terms/terms/view/id/5">Базовый вектор</a> общей системы оценки уязвимости CVSS v2.0'></span>
+            <div class="row">
+                <div class="col-xs-12">
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAV" name="VulFilterForm[bsAV]">
+<option value=""></option>
+<option value="L">L - Локальный</option>
+<option value="A">A - Смежная сеть</option>
+<option value="N">N - Сетевой</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAC" name="VulFilterForm[bsAC]">
+<option value=""></option>
+<option value="H">H - Высокая</option>
+<option value="M">M - Средняя</option>
+<option value="L">L - Низкая</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsAu" name="VulFilterForm[bsAu]">
+<option value=""></option>
+<option value="M">M - Множественная</option>
+<option value="S">S - Единственная</option>
+<option value="N">N - Не требуется</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsC" name="VulFilterForm[bsC]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsI" name="VulFilterForm[bsI]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                    <div class="col-xl-2 col-lg-4 col-xs-6 cvss"><select id="bsA" name="VulFilterForm[bsA]">
+<option value=""></option>
+<option value="N">N - Не оказывает</option>
+<option value="P">P - Частичное</option>
+<option value="C">C - Полное</option>
+</select></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_cwe">Идентификатор типа ошибки</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                              data-toggle="popover"
+                                                              data-content="Идентификатор, установленный в соответствии с общим перечнем ошибок CWE"></span>
+            <select multiple="multiple" name="VulFilterForm[cwe][]" id="VulFilterForm_cwe">
+<option value="">Все идентификаторы</option>
+<option value="1">CWE-1</option>
+<option value="2">CWE-2</option>
+<option value="3">CWE-3</option>
+<option value="4">CWE-4</option>
+<option value="5">CWE-5</option>
+<option value="6">CWE-6</option>
+<option value="7">CWE-7</option>
+<option value="8">CWE-8</option>
+<option value="9">CWE-9</option>
+<option value="10">CWE-10</option>
+<option value="11">CWE-11</option>
+<option value="12">CWE-12</option>
+<option value="13">CWE-13</option>
+<option value="14">CWE-14</option>
+<option value="15">CWE-15</option>
+<option value="16">CWE-16</option>
+<option value="17">CWE-17</option>
+<option value="18">CWE-18</option>
+<option value="19">CWE-19</option>
+<option value="20">CWE-20</option>
+<option value="21">CWE-21</option>
+<option value="22">CWE-22</option>
+<option value="23">CWE-23</option>
+<option value="24">CWE-24</option>
+<option value="25">CWE-25</option>
+<option value="26">CWE-26</option>
+<option value="27">CWE-27</option>
+<option value="28">CWE-28</option>
+<option value="29">CWE-29</option>
+<option value="30">CWE-30</option>
+<option value="31">CWE-31</option>
+<option value="32">CWE-32</option>
+<option value="33">CWE-33</option>
+<option value="34">CWE-34</option>
+<option value="35">CWE-35</option>
+<option value="36">CWE-36</option>
+<option value="37">CWE-37</option>
+<option value="38">CWE-38</option>
+<option value="39">CWE-39</option>
+<option value="40">CWE-40</option>
+<option value="41">CWE-41</option>
+<option value="42">CWE-42</option>
+<option value="43">CWE-43</option>
+<option value="44">CWE-44</option>
+<option value="45">CWE-45</option>
+<option value="46">CWE-46</option>
+<option value="47">CWE-47</option>
+<option value="48">CWE-48</option>
+<option value="49">CWE-49</option>
+<option value="50">CWE-50</option>
+<option value="51">CWE-51</option>
+<option value="52">CWE-52</option>
+<option value="53">CWE-53</option>
+<option value="54">CWE-54</option>
+<option value="55">CWE-55</option>
+<option value="56">CWE-56</option>
+<option value="57">CWE-57</option>
+<option value="58">CWE-58</option>
+<option value="59">CWE-59</option>
+<option value="60">CWE-60</option>
+<option value="61">CWE-61</option>
+<option value="62">CWE-62</option>
+<option value="63">CWE-63</option>
+<option value="64">CWE-64</option>
+<option value="65">CWE-65</option>
+<option value="66">CWE-66</option>
+<option value="67">CWE-67</option>
+<option value="68">CWE-68</option>
+<option value="69">CWE-69</option>
+<option value="70">CWE-70</option>
+<option value="71">CWE-71</option>
+<option value="72">CWE-72</option>
+<option value="73">CWE-73</option>
+<option value="74">CWE-74</option>
+<option value="75">CWE-75</option>
+<option value="76">CWE-76</option>
+<option value="77">CWE-77</option>
+<option value="78">CWE-78</option>
+<option value="79">CWE-79</option>
+<option value="80">CWE-80</option>
+<option value="81">CWE-81</option>
+<option value="82">CWE-82</option>
+<option value="83">CWE-83</option>
+<option value="84">CWE-84</option>
+<option value="85">CWE-85</option>
+<option value="86">CWE-86</option>
+<option value="87">CWE-87</option>
+<option value="88">CWE-88</option>
+<option value="89">CWE-89</option>
+<option value="90">CWE-90</option>
+<option value="91">CWE-91</option>
+<option value="92">CWE-92</option>
+<option value="93">CWE-93</option>
+<option value="94">CWE-94</option>
+<option value="95">CWE-95</option>
+<option value="96">CWE-96</option>
+<option value="97">CWE-97</option>
+<option value="98">CWE-98</option>
+<option value="99">CWE-99</option>
+<option value="100">CWE-100</option>
+<option value="101">CWE-101</option>
+<option value="102">CWE-102</option>
+<option value="103">CWE-103</option>
+<option value="104">CWE-104</option>
+<option value="105">CWE-105</option>
+<option value="106">CWE-106</option>
+<option value="107">CWE-107</option>
+<option value="108">CWE-108</option>
+<option value="109">CWE-109</option>
+<option value="110">CWE-110</option>
+<option value="111">CWE-111</option>
+<option value="112">CWE-112</option>
+<option value="113">CWE-113</option>
+<option value="114">CWE-114</option>
+<option value="115">CWE-115</option>
+<option value="116">CWE-116</option>
+<option value="117">CWE-117</option>
+<option value="118">CWE-118</option>
+<option value="119">CWE-119</option>
+<option value="120">CWE-120</option>
+<option value="121">CWE-121</option>
+<option value="122">CWE-122</option>
+<option value="123">CWE-123</option>
+<option value="124">CWE-124</option>
+<option value="125">CWE-125</option>
+<option value="126">CWE-126</option>
+<option value="127">CWE-127</option>
+<option value="128">CWE-128</option>
+<option value="129">CWE-129</option>
+<option value="130">CWE-130</option>
+<option value="131">CWE-131</option>
+<option value="132">CWE-132</option>
+<option value="133">CWE-133</option>
+<option value="134">CWE-134</option>
+<option value="135">CWE-135</option>
+<option value="136">CWE-136</option>
+<option value="137">CWE-137</option>
+<option value="138">CWE-138</option>
+<option value="139">CWE-139</option>
+<option value="140">CWE-140</option>
+<option value="141">CWE-141</option>
+<option value="142">CWE-142</option>
+<option value="143">CWE-143</option>
+<option value="144">CWE-144</option>
+<option value="145">CWE-145</option>
+<option value="146">CWE-146</option>
+<option value="147">CWE-147</option>
+<option value="148">CWE-148</option>
+<option value="149">CWE-149</option>
+<option value="150">CWE-150</option>
+<option value="151">CWE-151</option>
+<option value="152">CWE-152</option>
+<option value="153">CWE-153</option>
+<option value="154">CWE-154</option>
+<option value="155">CWE-155</option>
+<option value="156">CWE-156</option>
+<option value="157">CWE-157</option>
+<option value="158">CWE-158</option>
+<option value="159">CWE-159</option>
+<option value="160">CWE-160</option>
+<option value="161">CWE-161</option>
+<option value="162">CWE-162</option>
+<option value="163">CWE-163</option>
+<option value="164">CWE-164</option>
+<option value="165">CWE-165</option>
+<option value="166">CWE-166</option>
+<option value="167">CWE-167</option>
+<option value="168">CWE-168</option>
+<option value="169">CWE-169</option>
+<option value="170">CWE-170</option>
+<option value="171">CWE-171</option>
+<option value="172">CWE-172</option>
+<option value="173">CWE-173</option>
+<option value="174">CWE-174</option>
+<option value="175">CWE-175</option>
+<option value="176">CWE-176</option>
+<option value="177">CWE-177</option>
+<option value="178">CWE-178</option>
+<option value="179">CWE-179</option>
+<option value="180">CWE-180</option>
+<option value="181">CWE-181</option>
+<option value="182">CWE-182</option>
+<option value="183">CWE-183</option>
+<option value="184">CWE-184</option>
+<option value="185">CWE-185</option>
+<option value="186">CWE-186</option>
+<option value="187">CWE-187</option>
+<option value="188">CWE-188</option>
+<option value="189">CWE-189</option>
+<option value="190">CWE-190</option>
+<option value="191">CWE-191</option>
+<option value="192">CWE-192</option>
+<option value="193">CWE-193</option>
+<option value="194">CWE-194</option>
+<option value="195">CWE-195</option>
+<option value="196">CWE-196</option>
+<option value="197">CWE-197</option>
+<option value="198">CWE-198</option>
+<option value="199">CWE-199</option>
+<option value="200">CWE-200</option>
+<option value="201">CWE-201</option>
+<option value="202">CWE-202</option>
+<option value="203">CWE-203</option>
+<option value="204">CWE-204</option>
+<option value="205">CWE-205</option>
+<option value="206">CWE-206</option>
+<option value="207">CWE-207</option>
+<option value="208">CWE-208</option>
+<option value="209">CWE-209</option>
+<option value="210">CWE-210</option>
+<option value="211">CWE-211</option>
+<option value="212">CWE-212</option>
+<option value="213">CWE-213</option>
+<option value="214">CWE-214</option>
+<option value="215">CWE-215</option>
+<option value="216">CWE-216</option>
+<option value="217">CWE-217</option>
+<option value="218">CWE-218</option>
+<option value="219">CWE-219</option>
+<option value="220">CWE-220</option>
+<option value="221">CWE-221</option>
+<option value="222">CWE-222</option>
+<option value="223">CWE-223</option>
+<option value="224">CWE-224</option>
+<option value="225">CWE-225</option>
+<option value="226">CWE-226</option>
+<option value="227">CWE-227</option>
+<option value="228">CWE-228</option>
+<option value="229">CWE-229</option>
+<option value="230">CWE-230</option>
+<option value="231">CWE-231</option>
+<option value="232">CWE-232</option>
+<option value="233">CWE-233</option>
+<option value="234">CWE-234</option>
+<option value="235">CWE-235</option>
+<option value="236">CWE-236</option>
+<option value="237">CWE-237</option>
+<option value="238">CWE-238</option>
+<option value="239">CWE-239</option>
+<option value="240">CWE-240</option>
+<option value="241">CWE-241</option>
+<option value="242">CWE-242</option>
+<option value="243">CWE-243</option>
+<option value="244">CWE-244</option>
+<option value="245">CWE-245</option>
+<option value="246">CWE-246</option>
+<option value="247">CWE-247</option>
+<option value="248">CWE-248</option>
+<option value="249">CWE-249</option>
+<option value="250">CWE-250</option>
+<option value="251">CWE-251</option>
+<option value="252">CWE-252</option>
+<option value="253">CWE-253</option>
+<option value="254">CWE-254</option>
+<option value="255">CWE-255</option>
+<option value="256">CWE-256</option>
+<option value="257">CWE-257</option>
+<option value="258">CWE-258</option>
+<option value="259">CWE-259</option>
+<option value="260">CWE-260</option>
+<option value="261">CWE-261</option>
+<option value="262">CWE-262</option>
+<option value="263">CWE-263</option>
+<option value="264">CWE-264</option>
+<option value="265">CWE-265</option>
+<option value="266">CWE-266</option>
+<option value="267">CWE-267</option>
+<option value="268">CWE-268</option>
+<option value="269">CWE-269</option>
+<option value="270">CWE-270</option>
+<option value="271">CWE-271</option>
+<option value="272">CWE-272</option>
+<option value="273">CWE-273</option>
+<option value="274">CWE-274</option>
+<option value="275">CWE-275</option>
+<option value="276">CWE-276</option>
+<option value="277">CWE-277</option>
+<option value="278">CWE-278</option>
+<option value="279">CWE-279</option>
+<option value="280">CWE-280</option>
+<option value="281">CWE-281</option>
+<option value="282">CWE-282</option>
+<option value="283">CWE-283</option>
+<option value="284">CWE-284</option>
+<option value="285">CWE-285</option>
+<option value="286">CWE-286</option>
+<option value="287">CWE-287</option>
+<option value="288">CWE-288</option>
+<option value="289">CWE-289</option>
+<option value="290">CWE-290</option>
+<option value="291">CWE-291</option>
+<option value="292">CWE-292</option>
+<option value="293">CWE-293</option>
+<option value="294">CWE-294</option>
+<option value="295">CWE-295</option>
+<option value="296">CWE-296</option>
+<option value="297">CWE-297</option>
+<option value="298">CWE-298</option>
+<option value="299">CWE-299</option>
+<option value="300">CWE-300</option>
+<option value="301">CWE-301</option>
+<option value="302">CWE-302</option>
+<option value="303">CWE-303</option>
+<option value="304">CWE-304</option>
+<option value="305">CWE-305</option>
+<option value="306">CWE-306</option>
+<option value="307">CWE-307</option>
+<option value="308">CWE-308</option>
+<option value="309">CWE-309</option>
+<option value="310">CWE-310</option>
+<option value="311">CWE-311</option>
+<option value="312">CWE-312</option>
+<option value="313">CWE-313</option>
+<option value="314">CWE-314</option>
+<option value="315">CWE-315</option>
+<option value="316">CWE-316</option>
+<option value="317">CWE-317</option>
+<option value="318">CWE-318</option>
+<option value="319">CWE-319</option>
+<option value="320">CWE-320</option>
+<option value="321">CWE-321</option>
+<option value="322">CWE-322</option>
+<option value="323">CWE-323</option>
+<option value="324">CWE-324</option>
+<option value="325">CWE-325</option>
+<option value="326">CWE-326</option>
+<option value="327">CWE-327</option>
+<option value="328">CWE-328</option>
+<option value="329">CWE-329</option>
+<option value="330">CWE-330</option>
+<option value="331">CWE-331</option>
+<option value="332">CWE-332</option>
+<option value="333">CWE-333</option>
+<option value="334">CWE-334</option>
+<option value="335">CWE-335</option>
+<option value="336">CWE-336</option>
+<option value="337">CWE-337</option>
+<option value="338">CWE-338</option>
+<option value="339">CWE-339</option>
+<option value="340">CWE-340</option>
+<option value="341">CWE-341</option>
+<option value="342">CWE-342</option>
+<option value="343">CWE-343</option>
+<option value="344">CWE-344</option>
+<option value="345">CWE-345</option>
+<option value="346">CWE-346</option>
+<option value="347">CWE-347</option>
+<option value="348">CWE-348</option>
+<option value="349">CWE-349</option>
+<option value="350">CWE-350</option>
+<option value="351">CWE-351</option>
+<option value="352">CWE-352</option>
+<option value="353">CWE-353</option>
+<option value="354">CWE-354</option>
+<option value="355">CWE-355</option>
+<option value="356">CWE-356</option>
+<option value="357">CWE-357</option>
+<option value="358">CWE-358</option>
+<option value="359">CWE-359</option>
+<option value="360">CWE-360</option>
+<option value="361">CWE-361</option>
+<option value="362">CWE-362</option>
+<option value="363">CWE-363</option>
+<option value="364">CWE-364</option>
+<option value="365">CWE-365</option>
+<option value="366">CWE-366</option>
+<option value="367">CWE-367</option>
+<option value="368">CWE-368</option>
+<option value="369">CWE-369</option>
+<option value="370">CWE-370</option>
+<option value="371">CWE-371</option>
+<option value="372">CWE-372</option>
+<option value="373">CWE-373</option>
+<option value="374">CWE-374</option>
+<option value="375">CWE-375</option>
+<option value="376">CWE-376</option>
+<option value="377">CWE-377</option>
+<option value="378">CWE-378</option>
+<option value="379">CWE-379</option>
+<option value="380">CWE-380</option>
+<option value="381">CWE-381</option>
+<option value="382">CWE-382</option>
+<option value="383">CWE-383</option>
+<option value="384">CWE-384</option>
+<option value="385">CWE-385</option>
+<option value="386">CWE-386</option>
+<option value="387">CWE-387</option>
+<option value="388">CWE-388</option>
+<option value="389">CWE-389</option>
+<option value="390">CWE-390</option>
+<option value="391">CWE-391</option>
+<option value="392">CWE-392</option>
+<option value="393">CWE-393</option>
+<option value="394">CWE-394</option>
+<option value="395">CWE-395</option>
+<option value="396">CWE-396</option>
+<option value="397">CWE-397</option>
+<option value="398">CWE-398</option>
+<option value="399">CWE-399</option>
+<option value="400">CWE-400</option>
+<option value="401">CWE-401</option>
+<option value="402">CWE-402</option>
+<option value="403">CWE-403</option>
+<option value="404">CWE-404</option>
+<option value="405">CWE-405</option>
+<option value="406">CWE-406</option>
+<option value="407">CWE-407</option>
+<option value="408">CWE-408</option>
+<option value="409">CWE-409</option>
+<option value="410">CWE-410</option>
+<option value="411">CWE-411</option>
+<option value="412">CWE-412</option>
+<option value="413">CWE-413</option>
+<option value="414">CWE-414</option>
+<option value="415">CWE-415</option>
+<option value="416">CWE-416</option>
+<option value="417">CWE-417</option>
+<option value="418">CWE-418</option>
+<option value="419">CWE-419</option>
+<option value="420">CWE-420</option>
+<option value="421">CWE-421</option>
+<option value="422">CWE-422</option>
+<option value="423">CWE-423</option>
+<option value="424">CWE-424</option>
+<option value="425">CWE-425</option>
+<option value="426">CWE-426</option>
+<option value="427">CWE-427</option>
+<option value="428">CWE-428</option>
+<option value="429">CWE-429</option>
+<option value="430">CWE-430</option>
+<option value="431">CWE-431</option>
+<option value="432">CWE-432</option>
+<option value="433">CWE-433</option>
+<option value="434">CWE-434</option>
+<option value="435">CWE-435</option>
+<option value="436">CWE-436</option>
+<option value="437">CWE-437</option>
+<option value="438">CWE-438</option>
+<option value="439">CWE-439</option>
+<option value="440">CWE-440</option>
+<option value="441">CWE-441</option>
+<option value="442">CWE-442</option>
+<option value="443">CWE-443</option>
+<option value="444">CWE-444</option>
+<option value="445">CWE-445</option>
+<option value="446">CWE-446</option>
+<option value="447">CWE-447</option>
+<option value="448">CWE-448</option>
+<option value="449">CWE-449</option>
+<option value="450">CWE-450</option>
+<option value="451">CWE-451</option>
+<option value="452">CWE-452</option>
+<option value="453">CWE-453</option>
+<option value="454">CWE-454</option>
+<option value="455">CWE-455</option>
+<option value="456">CWE-456</option>
+<option value="457">CWE-457</option>
+<option value="458">CWE-458</option>
+<option value="459">CWE-459</option>
+<option value="460">CWE-460</option>
+<option value="461">CWE-461</option>
+<option value="462">CWE-462</option>
+<option value="463">CWE-463</option>
+<option value="464">CWE-464</option>
+<option value="465">CWE-465</option>
+<option value="466">CWE-466</option>
+<option value="467">CWE-467</option>
+<option value="468">CWE-468</option>
+<option value="469">CWE-469</option>
+<option value="470">CWE-470</option>
+<option value="471">CWE-471</option>
+<option value="472">CWE-472</option>
+<option value="473">CWE-473</option>
+<option value="474">CWE-474</option>
+<option value="475">CWE-475</option>
+<option value="476">CWE-476</option>
+<option value="477">CWE-477</option>
+<option value="478">CWE-478</option>
+<option value="479">CWE-479</option>
+<option value="480">CWE-480</option>
+<option value="481">CWE-481</option>
+<option value="482">CWE-482</option>
+<option value="483">CWE-483</option>
+<option value="484">CWE-484</option>
+<option value="485">CWE-485</option>
+<option value="486">CWE-486</option>
+<option value="487">CWE-487</option>
+<option value="488">CWE-488</option>
+<option value="489">CWE-489</option>
+<option value="490">CWE-490</option>
+<option value="491">CWE-491</option>
+<option value="492">CWE-492</option>
+<option value="493">CWE-493</option>
+<option value="494">CWE-494</option>
+<option value="495">CWE-495</option>
+<option value="496">CWE-496</option>
+<option value="497">CWE-497</option>
+<option value="498">CWE-498</option>
+<option value="499">CWE-499</option>
+<option value="500">CWE-500</option>
+<option value="501">CWE-501</option>
+<option value="502">CWE-502</option>
+<option value="503">CWE-503</option>
+<option value="504">CWE-504</option>
+<option value="505">CWE-505</option>
+<option value="506">CWE-506</option>
+<option value="507">CWE-507</option>
+<option value="508">CWE-508</option>
+<option value="509">CWE-509</option>
+<option value="510">CWE-510</option>
+<option value="511">CWE-511</option>
+<option value="512">CWE-512</option>
+<option value="513">CWE-513</option>
+<option value="514">CWE-514</option>
+<option value="515">CWE-515</option>
+<option value="516">CWE-516</option>
+<option value="517">CWE-517</option>
+<option value="518">CWE-518</option>
+<option value="519">CWE-519</option>
+<option value="520">CWE-520</option>
+<option value="521">CWE-521</option>
+<option value="522">CWE-522</option>
+<option value="523">CWE-523</option>
+<option value="524">CWE-524</option>
+<option value="525">CWE-525</option>
+<option value="526">CWE-526</option>
+<option value="527">CWE-527</option>
+<option value="528">CWE-528</option>
+<option value="529">CWE-529</option>
+<option value="530">CWE-530</option>
+<option value="531">CWE-531</option>
+<option value="532">CWE-532</option>
+<option value="533">CWE-533</option>
+<option value="534">CWE-534</option>
+<option value="535">CWE-535</option>
+<option value="536">CWE-536</option>
+<option value="537">CWE-537</option>
+<option value="538">CWE-538</option>
+<option value="539">CWE-539</option>
+<option value="540">CWE-540</option>
+<option value="541">CWE-541</option>
+<option value="542">CWE-542</option>
+<option value="543">CWE-543</option>
+<option value="544">CWE-544</option>
+<option value="545">CWE-545</option>
+<option value="546">CWE-546</option>
+<option value="547">CWE-547</option>
+<option value="548">CWE-548</option>
+<option value="549">CWE-549</option>
+<option value="550">CWE-550</option>
+<option value="551">CWE-551</option>
+<option value="552">CWE-552</option>
+<option value="553">CWE-553</option>
+<option value="554">CWE-554</option>
+<option value="555">CWE-555</option>
+<option value="556">CWE-556</option>
+<option value="557">CWE-557</option>
+<option value="558">CWE-558</option>
+<option value="559">CWE-559</option>
+<option value="560">CWE-560</option>
+<option value="561">CWE-561</option>
+<option value="562">CWE-562</option>
+<option value="563">CWE-563</option>
+<option value="564">CWE-564</option>
+<option value="565">CWE-565</option>
+<option value="566">CWE-566</option>
+<option value="567">CWE-567</option>
+<option value="568">CWE-568</option>
+<option value="569">CWE-569</option>
+<option value="570">CWE-570</option>
+<option value="571">CWE-571</option>
+<option value="572">CWE-572</option>
+<option value="573">CWE-573</option>
+<option value="574">CWE-574</option>
+<option value="575">CWE-575</option>
+<option value="576">CWE-576</option>
+<option value="577">CWE-577</option>
+<option value="578">CWE-578</option>
+<option value="579">CWE-579</option>
+<option value="580">CWE-580</option>
+<option value="581">CWE-581</option>
+<option value="582">CWE-582</option>
+<option value="583">CWE-583</option>
+<option value="584">CWE-584</option>
+<option value="585">CWE-585</option>
+<option value="586">CWE-586</option>
+<option value="587">CWE-587</option>
+<option value="588">CWE-588</option>
+<option value="589">CWE-589</option>
+<option value="590">CWE-590</option>
+<option value="591">CWE-591</option>
+<option value="592">CWE-592</option>
+<option value="593">CWE-593</option>
+<option value="594">CWE-594</option>
+<option value="595">CWE-595</option>
+<option value="596">CWE-596</option>
+<option value="597">CWE-597</option>
+<option value="598">CWE-598</option>
+<option value="599">CWE-599</option>
+<option value="600">CWE-600</option>
+<option value="601">CWE-601</option>
+<option value="602">CWE-602</option>
+<option value="603">CWE-603</option>
+<option value="604">CWE-604</option>
+<option value="605">CWE-605</option>
+<option value="606">CWE-606</option>
+<option value="607">CWE-607</option>
+<option value="608">CWE-608</option>
+<option value="609">CWE-609</option>
+<option value="610">CWE-610</option>
+<option value="611">CWE-611</option>
+<option value="612">CWE-612</option>
+<option value="613">CWE-613</option>
+<option value="614">CWE-614</option>
+<option value="615">CWE-615</option>
+<option value="616">CWE-616</option>
+<option value="617">CWE-617</option>
+<option value="618">CWE-618</option>
+<option value="619">CWE-619</option>
+<option value="620">CWE-620</option>
+<option value="621">CWE-621</option>
+<option value="622">CWE-622</option>
+<option value="623">CWE-623</option>
+<option value="624">CWE-624</option>
+<option value="625">CWE-625</option>
+<option value="626">CWE-626</option>
+<option value="627">CWE-627</option>
+<option value="628">CWE-628</option>
+<option value="629">CWE-629</option>
+<option value="630">CWE-630</option>
+<option value="631">CWE-631</option>
+<option value="632">CWE-632</option>
+<option value="633">CWE-633</option>
+<option value="634">CWE-634</option>
+<option value="635">CWE-635</option>
+<option value="636">CWE-636</option>
+<option value="637">CWE-637</option>
+<option value="638">CWE-638</option>
+<option value="639">CWE-639</option>
+<option value="640">CWE-640</option>
+<option value="641">CWE-641</option>
+<option value="642">CWE-642</option>
+<option value="643">CWE-643</option>
+<option value="644">CWE-644</option>
+<option value="645">CWE-645</option>
+<option value="646">CWE-646</option>
+<option value="647">CWE-647</option>
+<option value="648">CWE-648</option>
+<option value="649">CWE-649</option>
+<option value="650">CWE-650</option>
+<option value="651">CWE-651</option>
+<option value="652">CWE-652</option>
+<option value="653">CWE-653</option>
+<option value="654">CWE-654</option>
+<option value="655">CWE-655</option>
+<option value="656">CWE-656</option>
+<option value="657">CWE-657</option>
+<option value="658">CWE-658</option>
+<option value="659">CWE-659</option>
+<option value="660">CWE-660</option>
+<option value="661">CWE-661</option>
+<option value="662">CWE-662</option>
+<option value="663">CWE-663</option>
+<option value="664">CWE-664</option>
+<option value="665">CWE-665</option>
+<option value="666">CWE-666</option>
+<option value="667">CWE-667</option>
+<option value="668">CWE-668</option>
+<option value="669">CWE-669</option>
+<option value="670">CWE-670</option>
+<option value="671">CWE-671</option>
+<option value="672">CWE-672</option>
+<option value="673">CWE-673</option>
+<option value="674">CWE-674</option>
+<option value="675">CWE-675</option>
+<option value="676">CWE-676</option>
+<option value="677">CWE-677</option>
+<option value="678">CWE-678</option>
+<option value="679">CWE-679</option>
+<option value="680">CWE-680</option>
+<option value="681">CWE-681</option>
+<option value="682">CWE-682</option>
+<option value="683">CWE-683</option>
+<option value="684">CWE-684</option>
+<option value="685">CWE-685</option>
+<option value="686">CWE-686</option>
+<option value="687">CWE-687</option>
+<option value="688">CWE-688</option>
+<option value="689">CWE-689</option>
+<option value="690">CWE-690</option>
+<option value="691">CWE-691</option>
+<option value="692">CWE-692</option>
+<option value="693">CWE-693</option>
+<option value="694">CWE-694</option>
+<option value="695">CWE-695</option>
+<option value="696">CWE-696</option>
+<option value="697">CWE-697</option>
+<option value="698">CWE-698</option>
+<option value="699">CWE-699</option>
+<option value="700">CWE-700</option>
+<option value="701">CWE-701</option>
+<option value="702">CWE-702</option>
+<option value="703">CWE-703</option>
+<option value="704">CWE-704</option>
+<option value="705">CWE-705</option>
+<option value="706">CWE-706</option>
+<option value="707">CWE-707</option>
+<option value="708">CWE-708</option>
+<option value="709">CWE-709</option>
+<option value="710">CWE-710</option>
+<option value="711">CWE-711</option>
+<option value="712">CWE-712</option>
+<option value="713">CWE-713</option>
+<option value="714">CWE-714</option>
+<option value="715">CWE-715</option>
+<option value="716">CWE-716</option>
+<option value="717">CWE-717</option>
+<option value="718">CWE-718</option>
+<option value="719">CWE-719</option>
+<option value="720">CWE-720</option>
+<option value="721">CWE-721</option>
+<option value="722">CWE-722</option>
+<option value="723">CWE-723</option>
+<option value="724">CWE-724</option>
+<option value="725">CWE-725</option>
+<option value="726">CWE-726</option>
+<option value="727">CWE-727</option>
+<option value="728">CWE-728</option>
+<option value="729">CWE-729</option>
+<option value="730">CWE-730</option>
+<option value="731">CWE-731</option>
+<option value="732">CWE-732</option>
+<option value="733">CWE-733</option>
+<option value="734">CWE-734</option>
+<option value="735">CWE-735</option>
+<option value="736">CWE-736</option>
+<option value="737">CWE-737</option>
+<option value="738">CWE-738</option>
+<option value="739">CWE-739</option>
+<option value="740">CWE-740</option>
+<option value="741">CWE-741</option>
+<option value="742">CWE-742</option>
+<option value="743">CWE-743</option>
+<option value="744">CWE-744</option>
+<option value="745">CWE-745</option>
+<option value="746">CWE-746</option>
+<option value="747">CWE-747</option>
+<option value="748">CWE-748</option>
+<option value="749">CWE-749</option>
+<option value="750">CWE-750</option>
+<option value="751">CWE-751</option>
+<option value="752">CWE-752</option>
+<option value="753">CWE-753</option>
+<option value="754">CWE-754</option>
+<option value="755">CWE-755</option>
+<option value="756">CWE-756</option>
+<option value="757">CWE-757</option>
+<option value="758">CWE-758</option>
+<option value="759">CWE-759</option>
+<option value="760">CWE-760</option>
+<option value="761">CWE-761</option>
+<option value="762">CWE-762</option>
+<option value="763">CWE-763</option>
+<option value="764">CWE-764</option>
+<option value="765">CWE-765</option>
+<option value="766">CWE-766</option>
+<option value="767">CWE-767</option>
+<option value="768">CWE-768</option>
+<option value="769">CWE-769</option>
+<option value="770">CWE-770</option>
+<option value="771">CWE-771</option>
+<option value="772">CWE-772</option>
+<option value="773">CWE-773</option>
+<option value="774">CWE-774</option>
+<option value="775">CWE-775</option>
+<option value="776">CWE-776</option>
+<option value="777">CWE-777</option>
+<option value="778">CWE-778</option>
+<option value="779">CWE-779</option>
+<option value="780">CWE-780</option>
+<option value="781">CWE-781</option>
+<option value="782">CWE-782</option>
+<option value="783">CWE-783</option>
+<option value="784">CWE-784</option>
+<option value="785">CWE-785</option>
+<option value="786">CWE-786</option>
+<option value="787">CWE-787</option>
+<option value="788">CWE-788</option>
+<option value="789">CWE-789</option>
+<option value="790">CWE-790</option>
+<option value="791">CWE-791</option>
+<option value="792">CWE-792</option>
+<option value="793">CWE-793</option>
+<option value="794">CWE-794</option>
+<option value="795">CWE-795</option>
+<option value="796">CWE-796</option>
+<option value="797">CWE-797</option>
+<option value="798">CWE-798</option>
+<option value="799">CWE-799</option>
+<option value="800">CWE-800</option>
+<option value="801">CWE-801</option>
+<option value="802">CWE-802</option>
+<option value="803">CWE-803</option>
+<option value="804">CWE-804</option>
+<option value="805">CWE-805</option>
+<option value="806">CWE-806</option>
+<option value="807">CWE-807</option>
+<option value="808">CWE-808</option>
+<option value="809">CWE-809</option>
+<option value="810">CWE-810</option>
+<option value="811">CWE-811</option>
+<option value="812">CWE-812</option>
+<option value="813">CWE-813</option>
+<option value="814">CWE-814</option>
+<option value="815">CWE-815</option>
+<option value="816">CWE-816</option>
+<option value="817">CWE-817</option>
+<option value="818">CWE-818</option>
+<option value="819">CWE-819</option>
+<option value="820">CWE-820</option>
+<option value="821">CWE-821</option>
+<option value="822">CWE-822</option>
+<option value="823">CWE-823</option>
+<option value="824">CWE-824</option>
+<option value="825">CWE-825</option>
+<option value="826">CWE-826</option>
+<option value="827">CWE-827</option>
+<option value="828">CWE-828</option>
+<option value="829">CWE-829</option>
+<option value="830">CWE-830</option>
+<option value="831">CWE-831</option>
+<option value="832">CWE-832</option>
+<option value="833">CWE-833</option>
+<option value="834">CWE-834</option>
+<option value="835">CWE-835</option>
+<option value="836">CWE-836</option>
+<option value="837">CWE-837</option>
+<option value="838">CWE-838</option>
+<option value="839">CWE-839</option>
+<option value="840">CWE-840</option>
+<option value="841">CWE-841</option>
+<option value="842">CWE-842</option>
+<option value="843">CWE-843</option>
+<option value="844">CWE-844</option>
+<option value="845">CWE-845</option>
+<option value="846">CWE-846</option>
+<option value="847">CWE-847</option>
+<option value="848">CWE-848</option>
+<option value="849">CWE-849</option>
+<option value="850">CWE-850</option>
+<option value="851">CWE-851</option>
+<option value="852">CWE-852</option>
+<option value="853">CWE-853</option>
+<option value="854">CWE-854</option>
+<option value="855">CWE-855</option>
+<option value="856">CWE-856</option>
+<option value="857">CWE-857</option>
+<option value="858">CWE-858</option>
+<option value="859">CWE-859</option>
+<option value="860">CWE-860</option>
+<option value="861">CWE-861</option>
+<option value="862">CWE-862</option>
+<option value="863">CWE-863</option>
+<option value="864">CWE-864</option>
+<option value="865">CWE-865</option>
+<option value="866">CWE-866</option>
+<option value="867">CWE-867</option>
+<option value="868">CWE-868</option>
+<option value="869">CWE-869</option>
+<option value="870">CWE-870</option>
+<option value="871">CWE-871</option>
+<option value="872">CWE-872</option>
+<option value="873">CWE-873</option>
+<option value="874">CWE-874</option>
+<option value="875">CWE-875</option>
+<option value="876">CWE-876</option>
+<option value="877">CWE-877</option>
+<option value="878">CWE-878</option>
+<option value="879">CWE-879</option>
+<option value="880">CWE-880</option>
+<option value="881">CWE-881</option>
+<option value="882">CWE-882</option>
+<option value="883">CWE-883</option>
+<option value="884">CWE-884</option>
+<option value="885">CWE-885</option>
+<option value="886">CWE-886</option>
+<option value="887">CWE-887</option>
+<option value="888">CWE-888</option>
+<option value="889">CWE-889</option>
+<option value="890">CWE-890</option>
+<option value="891">CWE-891</option>
+<option value="892">CWE-892</option>
+<option value="893">CWE-893</option>
+<option value="894">CWE-894</option>
+<option value="895">CWE-895</option>
+<option value="896">CWE-896</option>
+<option value="897">CWE-897</option>
+<option value="898">CWE-898</option>
+<option value="899">CWE-899</option>
+<option value="900">CWE-900</option>
+<option value="901">CWE-901</option>
+<option value="902">CWE-902</option>
+<option value="903">CWE-903</option>
+<option value="904">CWE-904</option>
+<option value="905">CWE-905</option>
+<option value="906">CWE-906</option>
+<option value="907">CWE-907</option>
+<option value="908">CWE-908</option>
+<option value="909">CWE-909</option>
+<option value="910">CWE-910</option>
+<option value="911">CWE-911</option>
+<option value="912">CWE-912</option>
+<option value="913">CWE-913</option>
+<option value="914">CWE-914</option>
+<option value="915">CWE-915</option>
+<option value="916">CWE-916</option>
+<option value="917">CWE-917</option>
+<option value="918">CWE-918</option>
+<option value="919">CWE-919</option>
+<option value="920">CWE-920</option>
+<option value="921">CWE-921</option>
+<option value="922">CWE-922</option>
+<option value="923">CWE-923</option>
+<option value="924">CWE-924</option>
+<option value="925">CWE-925</option>
+<option value="926">CWE-926</option>
+<option value="927">CWE-927</option>
+<option value="928">CWE-928</option>
+<option value="929">CWE-929</option>
+<option value="930">CWE-930</option>
+<option value="931">CWE-931</option>
+<option value="932">CWE-932</option>
+<option value="933">CWE-933</option>
+<option value="934">CWE-934</option>
+<option value="935">CWE-935</option>
+<option value="936">CWE-936</option>
+<option value="937">CWE-937</option>
+<option value="938">CWE-938</option>
+<option value="1001">CWE-943</option>
+<option value="1002">CWE-941</option>
+<option value="1003">CWE-1103</option>
+<option value="1004">CWE-942</option>
+<option value="1005">CWE-1188</option>
+<option value="1006">CWE-1021</option>
+<option value="1007">CWE-1236</option>
+<option value="1008">CWE-1321</option>
+<option value="1009">CWE-939</option>
+<option value="1010">CWE-1050</option>
+<option value="1011">CWE-1284</option>
+<option value="1012">CWE-1287</option>
+<option value="1013">CWE-1112</option>
+<option value="1014">CWE-1300</option>
+<option value="1015">CWE-1283</option>
+<option value="1016">CWE-1037</option>
+<option value="1017">CWE-1286</option>
+<option value="1018">CWE-1333</option>
+<option value="1019">CWE-1285</option>
+<option value="1022">CWE-1275</option>
+<option value="1023">CWE-1288</option>
+<option value="1024">CWE-1059</option>
+<option value="1025">CWE-1326</option>
+<option value="1026">CWE-1247</option>
+<option value="1027">CWE-1250</option>
+<option value="1028">CWE-1263</option>
+<option value="1029">CWE-1320</option>
+<option value="1030">CWE-1015</option>
+<option value="1031">CWE-1393</option>
+<option value="1032">CWE-1327</option>
+<option value="1033">CWE-1342</option>
+<option value="1034">CWE-1068</option>
+<option value="1035">CWE-1004</option>
+<option value="1036">CWE-1173</option>
+<option value="1037">CWE-1077</option>
+<option value="1038">CWE-1390</option>
+<option value="1039">CWE-1336</option>
+<option value="1040">CWE-1386</option>
+<option value="1041">CWE-1259</option>
+<option value="1042">CWE-1334</option>
+<option value="1043">CWE-1281</option>
+<option value="1044">CWE-1104</option>
+<option value="1045">CWE-1392</option>
+<option value="1046">CWE-1018</option>
+<option value="1047">CWE-1125</option>
+<option value="1048">CWE-1039</option>
+<option value="1049">CWE-940</option>
+<option value="1050">CWE-1269</option>
+<option value="1051">CWE-1385</option>
+<option value="1052">CWE-1220</option>
+<option value="1053">CWE-1262</option>
+<option value="1054">CWE-1395</option>
+<option value="1055">CWE-1191</option>
+<option value="1056">CWE-1303</option>
+<option value="1057">CWE-1394</option>
+<option value="1058">CWE-1423</option>
+<option value="1059">CWE-1107</option>
+<option value="1060">CWE-1389</option>
+<option value="1061">CWE-1251</option>
+<option value="1062">CWE-1245</option>
+<option value="1063">CWE-1391</option>
+<option value="1064">CWE-1189</option>
+<option value="1065">CWE-1325</option>
+<option value="1066">CWE-1025</option>
+<option value="1067">CWE-1295</option>
+<option value="1068">CWE-1298</option>
+<option value="1069">CWE-1242</option>
+<option value="1070">CWE-1297</option>
+<option value="1071">CWE-1230</option>
+<option value="1072">CWE-1222</option>
+<option value="1073">CWE-1335</option>
+<option value="1074">CWE-1341</option>
+<option value="1075">CWE-1023</option>
+<option value="1076">CWE-1289</option>
+<option value="1077">CWE-1277</option>
+<option value="1078">CWE-1384</option>
+<option value="1079">CWE-1244</option>
+<option value="1080">CWE-1258</option>
+<option value="1081">CWE-1264</option>
+<option value="1082">CWE-1240</option>
+<option value="1083">CWE-1256</option>
+<option value="1084">CWE-1322</option>
+<option value="1085">CWE-1100</option>
+<option value="1086">CWE-1257</option>
+<option value="1087">CWE-1164</option>
+<option value="1088">CWE-1419</option>
+<option value="1089">CWE-1233</option>
+<option value="1090">CWE-1102</option>
+<option value="1091">CWE-1176</option>
+<option value="1092">CWE-1426</option>
+<option value="1093">CWE-1060</option>
+<option value="1094">CWE-1120</option>
+<option value="1095">CWE-1260</option>
+<option value="1096">CWE-1422</option>
+<option value="1097">CWE-1022</option>
+<option value="1098">CWE-1329</option>
+<option value="1099">CWE-1177</option>
+<option value="1100">CWE-1231</option>
+<option value="1101">CWE-1091</option>
+<option value="1102">CWE-1108</option>
+<option value="1103">CWE-1006</option>
+<option value="1104">CWE-1211</option>
+</select>            <div class="errorMessage" id="VulFilterForm_cwe_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_idval">Другие системы идентификации</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                data-toggle="popover"
+                                                                data-content="Идентификаторы других систем учета уязвимостей"></span>
+            <input empty="All idents" multiple="multiple" name="VulFilterForm[idval]" id="VulFilterForm_idval" type="hidden" />            <div class="errorMessage" id="VulFilterForm_idval_em_" style="display:none"></div>        </div>
+
+
+        
+        <div class="form-group">
+            <label for="VulFilterForm_vul_expl">Наличие эксплойта</label>            <select name="VulFilterForm[vul_expl]" id="VulFilterForm_vul_expl">
+<option value=""></option>
+<option value="0">Данные уточняются</option>
+<option value="1">Существует</option>
+<option value="2">Существует в открытом доступе</option>
+</select>            <div class="errorMessage" id="VulFilterForm_vul_expl_em_" style="display:none"></div>        </div>
+
+
+        <div class="form-group">
+            <label for="VulFilterForm_operProc">Способ эксплуатации</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                   data-toggle="popover"
+                                                                   data-content="Способ эксплуатации уязвимости"></span>
+            <select name="VulFilterForm[operProc]" id="VulFilterForm_operProc">
+<option value=""></option>
+<option value="1">Несанкционированный сбор информации</option>
+<option value="2">Исчерпание ресурсов</option>
+<option value="3">Инъекция</option>
+<option value="4">Анализ целевого объекта</option>
+<option value="5">Подмена при взаимодействии</option>
+<option value="6">Злоупотребление функционалом</option>
+<option value="7">Нарушение авторизации</option>
+<option value="8">Нарушение аутентификации</option>
+<option value="9">Манипулирование структурами данных</option>
+<option value="10">Манипулирование ресурсами</option>
+<option value="11">Манипулирование сроками и состоянием</option>
+<option value="12">Вероятностные методы</option>
+</select>            <div class="errorMessage" id="VulFilterForm_operProc_em_" style="display:none"></div>        </div>
+
+        <div class="form-group">
+            <label for="VulFilterForm_vul_elimination">Способ устранения</label><span
+                    class="glyphicon glyphicon-question-sign help-hint" data-toggle="popover"
+                    data-content="Способ устранения уязвимости"></span>
+            <select name="VulFilterForm[vul_elimination]" id="VulFilterForm_vul_elimination">
+<option value=""></option>
+<option value="0">Данные уточняются</option>
+<option value="1">Обновление программного обеспечения</option>
+<option value="2">Организационные меры</option>
+</select>            <div class="errorMessage" id="VulFilterForm_vul_elimination_em_" style="display:none"></div>        </div>
+
+
+        <div class="form-group">
+            <label for="VulFilterForm_osystem">Операционная система</label><span class="glyphicon glyphicon-question-sign help-hint"
+                                                                  data-toggle="popover"
+                                                                  data-content="Операционная система, под управлением которой функционирует программное обеспечение с обнаруженной уязвимостью"></span>
+            <input name="VulFilterForm[osystem]" id="VulFilterForm_osystem" type="hidden" />            <div class="errorMessage" id="VulFilterForm_osystem_em_" style="display:none"></div>        </div>
+    </div>
+</div>
+
+
+<div class="form-group text-center">
+    <input name="clear" class="btn btn-default" type="submit" value="Сброс" />    <input name="fl" class="btn btn-success" type="submit" value="Применить" /></div>
+
+</form><script>
+    var webroot = "";
+</script>
+
+</div>
+</div>    </div>
+    <div class="col-sm-12 col-md-3 col-lg-3">
+        <div class="portlet" id="yw3">
+<div class="portlet-decoration">
+<div class="portlet-right-decoration-inner">
+<div class="portlet-title">Последние изменения</div>
+</div>
+</div>
+<div class="portlet-content">
+<ul class="list-news">
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03438">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с неограниченным распределением ресурсов, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03437">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с использованием имени с неправильной ссылкой, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03436">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с непринятием мер по защите структуры веб-страницы, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03435">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с обходом аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю получить несанкционированный доступ к защищаемой информации</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03434">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03433">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab, связанная с распределением ресурсов без ограничений или регулирования, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03432">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab связанная с использованием регулярного выражения с неэффективной вычислительной сложностью, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03431">Уязвимость интерфейса Mermaid UI программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю выполнить произвольный код</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03430">Уязвимость прикладного программного интерфейса программной платформы на базе git для совместной работы над кодом GitLab, позволяющая нарушителю вызвать отказ в обслуживании</a>	</li>
+		<li>
+        <span class="small">20.03.2026</span>
+
+        
+        <a href="/vul/2026-03429">Уязвимость программной платформы на базе git для совместной работы над кодом GitLab Enterprise Edition (EE), связанная с обходом процедуры аутентификации посредством использования альтернативного пути или канала, позволяющая нарушителю обойти существующие механизмы безопасности</a>	</li>
+	</ul>
+
+</div>
+</div>    </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="footer">
+        <div class="portlet-full summary" id="yw4">
+<div class="portlet-content">
+<p>Угрозы: <span class="badge">227</span> Уязвимости: <span class="badge">84542</span> Последнее обновление: <span class="badge">20.03.2026</span></p>
+</div>
+</div>        		<p class="text-center">&copy; ФАУ &laquo;ГНИИИ ПТЗИ ФСТЭК России&raquo;</p>
+        <div id="counters" class="text-left">
+                            <!-- Yandex.Metrika informer -->
+                <a href="https://metrika.yandex.ru/stat/?id=28243701&amp;from=informer"
+                   target="_blank" rel="nofollow noopener noreferrer"><img src="https://informer.yandex.ru/informer/28243701/3_0_707070FF_505050FF_1_pageviews"
+                                                       style="width:88px; height:31px; border:0;" alt="Яндекс.Метрика" title="Яндекс.Метрика: данные за сегодня (просмотры, визиты и уникальные посетители)" class="ym-advanced-informer" data-cid="28243701" data-lang="ru" /></a>
+                <!-- /Yandex.Metrika informer -->
+
+                <!-- Yandex.Metrika counter -->
+                <script type="text/javascript" >
+                    (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+                        m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+                    (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+                    ym(28243701, "init", {
+                        clickmap:true,
+                        trackLinks:true,
+                        accurateTrackBounce:true
+                    });
+                </script>
+                <noscript><div><img src="https://mc.yandex.ru/watch/28243701" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+                <!-- /Yandex.Metrika counter -->
+                    </div>
+    </div>
+
+    <script src="/themes/fstec/js/bootstrap.min.js"></script>
+    <script src="/themes/fstec/js/affix.js"></script>
+    <script>
+        $(function(){
+            $('#top-nav').affix({
+                offset: {
+                    top: $('.page-header').outerHeight(true)
+                }
+            });
+        })
+        window.onload = function () {
+        document.body.classList.add('loaded_hiding');
+        window.setTimeout(function () {
+            document.body.classList.add('loaded');
+            document.body.classList.remove('loaded_hiding');
+        }, 500);
+
+        document.getElementsByTagName('body')[0].onclick = function (e) {
+            let target = e && e.target || event.srcElement;
+            if(e.ctrlKey === true || e.shiftKey === true || e.altKey === true)
+                return;
+            if (target.tagName === "A" || target.tagName === "INPUT") {
+                if (target?.classList.contains('dropdown-toggle')
+                    || target?.classList.contains('toggle')
+                    || target?.classList.contains('dropdown')
+                    || target?.hash !== undefined && target?.hash !== ""
+                    || target?.href !== undefined && target?.href.includes('#')
+                    || target?.href !== undefined && target?.href.includes('blob:')
+                    || target?.href !== undefined && target?.href.includes('/site/agreement')
+                    || target?.href !== undefined && target?.href.includes('/bdu_public.key')
+                    || target?.href !== undefined && target?.href.includes('/files/')
+                    || target?.href !== undefined && target?.href.includes('/education')
+                    || target?.href !== undefined && target?.href.includes('/education/')
+                    || target?.href !== undefined && target?.href.includes('/software-section')
+                    || target?.href !== undefined && target?.href.includes('/software-section/')
+                    || target?.href !== undefined && target?.href.includes('/threat-section')
+                    || target?.href !== undefined && target?.href.includes('/threat-section/')
+                    || target?.href !== undefined && target?.href.includes('/mailing-profiles')
+                    || target?.href !== undefined && target?.href.includes('/mailing-profiles/')
+                    || target?.href !== undefined && target?.href === ""
+                    || target?.download !== undefined && target?.download !== ""
+                    || target.tagName === "INPUT" && target.type !== "submit") {
+                    return;
+                }
+                if (target.target !== "_blank" || target.type === "submit") {
+                    $(document).on("ajaxComplete", function (event, xhr, settings) {
+                        document.body.classList.add('loaded_hiding');
+                        window.setTimeout(function () {
+                            document.body.classList.add('loaded');
+                            document.body.classList.remove('loaded_hiding');
+                        }, 500);
+                    });
+                    document.body.classList.remove('loaded');
+                }
+            }
+        }
+    }
+    </script>
+
+
+    <script type="text/javascript" src="/assets/d68f76a4/listview/jquery.yiilistview.js"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+jQuery(function($) {
+jQuery('#vuls').yiiListView({'ajaxUpdate':['vuls'],'ajaxVar':'ajax','pagerClass':'link\x2Dpager','loadingClass':'list\x2Dview\x2Dloading','sorterClass':'sorter','enableHistory':false,'afterAjaxUpdate': function(){setVulsTooltip()}});
+jQuery('#vul-filter-form').yiiactiveform({'validateOnSubmit':false,'validateOnChange':false,'validateOnType':false,'attributes':[{'id':'VulFilterForm_vendor','inputID':'VulFilterForm_vendor','errorID':'VulFilterForm_vendor_em_','model':'VulFilterForm','name':'vendor','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_softType','inputID':'VulFilterForm_softType','errorID':'VulFilterForm_softType_em_','model':'VulFilterForm','name':'softType','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_soft','inputID':'VulFilterForm_soft','errorID':'VulFilterForm_soft_em_','model':'VulFilterForm','name':'soft','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_platf','inputID':'VulFilterForm_platf','errorID':'VulFilterForm_platf_em_','model':'VulFilterForm','name':'platf','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_version','inputID':'VulFilterForm_version','errorID':'VulFilterForm_version_em_','model':'VulFilterForm','name':'version','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_state','inputID':'VulFilterForm_vul_state','errorID':'VulFilterForm_vul_state_em_','model':'VulFilterForm','name':'vul_state','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_toDate','inputID':'VulFilterForm_toDate','errorID':'VulFilterForm_toDate_em_','model':'VulFilterForm','name':'toDate','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_incident','inputID':'VulFilterForm_vul_incident','errorID':'VulFilterForm_vul_incident_em_','model':'VulFilterForm','name':'vul_incident','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_extended_desc','inputID':'VulFilterForm_vul_extended_desc','errorID':'VulFilterForm_vul_extended_desc_em_','model':'VulFilterForm','name':'vul_extended_desc','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_yearAdd','inputID':'VulFilterForm_yearAdd','errorID':'VulFilterForm_yearAdd_em_','model':'VulFilterForm','name':'yearAdd','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_clvul','inputID':'VulFilterForm_clvul','errorID':'VulFilterForm_clvul_em_','model':'VulFilterForm','name':'clvul','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_bsLevel','inputID':'VulFilterForm_bsLevel','errorID':'VulFilterForm_bsLevel_em_','model':'VulFilterForm','name':'bsLevel','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_cwe','inputID':'VulFilterForm_cwe','errorID':'VulFilterForm_cwe_em_','model':'VulFilterForm','name':'cwe','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_idval','inputID':'VulFilterForm_idval','errorID':'VulFilterForm_idval_em_','model':'VulFilterForm','name':'idval','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_expl','inputID':'VulFilterForm_vul_expl','errorID':'VulFilterForm_vul_expl_em_','model':'VulFilterForm','name':'vul_expl','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_operProc','inputID':'VulFilterForm_operProc','errorID':'VulFilterForm_operProc_em_','model':'VulFilterForm','name':'operProc','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_vul_elimination','inputID':'VulFilterForm_vul_elimination','errorID':'VulFilterForm_vul_elimination_em_','model':'VulFilterForm','name':'vul_elimination','enableAjaxValidation':true,'summary':true},{'id':'VulFilterForm_osystem','inputID':'VulFilterForm_osystem','errorID':'VulFilterForm_osystem_em_','model':'VulFilterForm','name':'osystem','enableAjaxValidation':true,'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true},{'summary':true}],'summaryID':'vul\x2Dfilter\x2Dform_es_','errorCss':'error'});
+});
+/*]]>*/
+</script>
+</body>
+</html>

--- a/tests/unit/sbom_pipeline/enrichters/test_bdu.py
+++ b/tests/unit/sbom_pipeline/enrichters/test_bdu.py
@@ -1,0 +1,230 @@
+from pathlib import Path
+import sys
+
+import requests
+
+ROOT = Path(__file__).resolve().parents[4]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sbom_pipeline.enrichters import bdu
+
+
+class FakeCookies:
+    def __init__(self, initial=None):
+        self._data = dict(initial or {})
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+class FakeResponse:
+    def __init__(self, text="", cookies=None, status_code=200):
+        self.text = text
+        self.cookies = FakeCookies(cookies)
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class FakeRequestsGet:
+    def __init__(
+        self,
+        search_results=None,
+        failing_cves=None,
+        cookie_token='%22query-token%22',
+        php_session_id="session-id",
+    ):
+        self.search_results = dict(search_results or {})
+        self.failing_cves = set(failing_cves or set())
+        self.cookie_token = cookie_token
+        self.php_session_id = php_session_id
+        self.calls = []
+
+    def __call__(self, url, params=None, timeout=None, verify=None, headers=None, cookies=None):
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "timeout": timeout,
+                "verify": verify,
+                "headers": headers,
+                "cookies": cookies,
+            }
+        )
+
+        if params is None:
+            return FakeResponse(
+                cookies={
+                    "YII_CSRF_TOKEN": self.cookie_token,
+                    "PHPSESSID": self.php_session_id,
+                }
+            )
+
+        search_value = params["VulFilterForm[idval]"]
+        if search_value in self.failing_cves:
+            raise requests.RequestException("network error")
+
+        bdu_id = self.search_results.get(search_value)
+        if not bdu_id:
+            return FakeResponse("<html><body>No results</body></html>")
+
+        html = f"""
+        <div id="vuls">
+          <table class="table table-striped table-vuls">
+              <tr>
+                <td class="col-lg-3 col-xs-3">
+                  <h4><a class="confirm-vul" href="/vul/mock">{bdu_id}</a></h4>
+                </td>
+              </tr>
+          </table>
+        </div>
+        """
+        return FakeResponse(html)
+
+
+def test_get_bdu_ids_by_cves_returns_dict_for_found_cves(monkeypatch):
+    fake_get = FakeRequestsGet(
+        search_results={
+            "2024-0001": "BDU:2024-00001",
+            "2024-0002": "BDU:2024-00002",
+        }
+    )
+    monkeypatch.setattr(bdu.requests, "get", fake_get)
+
+    result = bdu.get_bdu_ids_by_cves(["CVE-2024-0001", "CVE-2024-0002"])
+
+    assert result == {
+        "CVE-2024-0001": "BDU:2024-00001",
+        "CVE-2024-0002": "BDU:2024-00002",
+    }
+
+    search_calls = [call for call in fake_get.calls if call["params"] is not None]
+    assert len(search_calls) == 2
+    assert fake_get.calls[0]["params"] is None
+    assert fake_get.calls[0]["verify"] is False
+    assert fake_get.calls[0]["timeout"] == bdu.REQUEST_TIMEOUT
+    assert fake_get.calls[0]["headers"] == bdu.DEFAULT_HEADERS
+    assert fake_get.calls[0]["cookies"] is None
+    assert search_calls[0]["params"]["YII_CSRF_TOKEN"] == "query-token"
+    assert search_calls[0]["params"]["VulFilterForm[idval]"] == "2024-0001"
+    assert search_calls[1]["params"]["VulFilterForm[idval]"] == "2024-0002"
+    assert search_calls[0]["verify"] is False
+    assert search_calls[1]["verify"] is False
+    assert search_calls[0]["timeout"] == bdu.REQUEST_TIMEOUT
+    assert search_calls[1]["timeout"] == bdu.REQUEST_TIMEOUT
+    assert search_calls[0]["cookies"] == {
+        "YII_CSRF_TOKEN": "%22query-token%22",
+        "PHPSESSID": "session-id",
+    }
+
+
+def test_get_bdu_ids_by_cves_skips_not_found_and_failed_requests(monkeypatch):
+    fake_get = FakeRequestsGet(
+        search_results={"2024-0001": "BDU:2024-00001"},
+        failing_cves={"2024-0003"},
+    )
+    monkeypatch.setattr(bdu.requests, "get", fake_get)
+
+    result = bdu.get_bdu_ids_by_cves(
+        ["CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0003"]
+    )
+
+    assert result == {
+        "CVE-2024-0001": "BDU:2024-00001",
+    }
+
+
+def test_get_bdu_ids_by_cves_returns_empty_dict_for_empty_input():
+    assert bdu.get_bdu_ids_by_cves([]) == {}
+    assert bdu.get_bdu_ids_by_cves(["", "   "]) == {}
+
+
+def test_extract_query_token_decodes_cookie_value():
+    assert bdu._extract_query_token("%22query-token%22") == "query-token"
+
+
+def test_outgoing_token_param_is_urlencoded(monkeypatch):
+    fake_get = FakeRequestsGet(search_results={"2024-0001": "BDU:2024-00001"})
+    monkeypatch.setattr(bdu.requests, "get", fake_get)
+    token = "MXFNX3JSMDVhVHB1aG5GdH5abGtzSXB6UHN3Z3FDaEfoi3zMNAVr3f4467gBT3vvq7kwsHY_WHa5kSFgcIupqg=="
+    monkeypatch.setattr(
+        bdu,
+        "_get_csrf_tokens",
+        lambda: ({"YII_CSRF_TOKEN": token, "PHPSESSID": "session-id"}, token),
+    )
+
+    bdu.get_bdu_ids_by_cves(["CVE-2024-0001"])
+
+    search_call = next(call for call in fake_get.calls if call["params"] is not None)
+    assert (
+        search_call["params"]["YII_CSRF_TOKEN"]
+        == "MXFNX3JSMDVhVHB1aG5GdH5abGtzSXB6UHN3Z3FDaEfoi3zMNAVr3f4467gBT3vvq7kwsHY_WHa5kSFgcIupqg%3D%3D"
+    )
+
+
+def test_get_csrf_tokens_returns_cookie_and_query_token(monkeypatch):
+    fake_get = FakeRequestsGet(cookie_token="%22csrf-query-token%22")
+    monkeypatch.setattr(bdu.requests, "get", fake_get)
+
+    cookie_jar, query_token = bdu._get_csrf_tokens()
+
+    assert cookie_jar == {
+        "YII_CSRF_TOKEN": "%22csrf-query-token%22",
+        "PHPSESSID": "session-id",
+    }
+    assert query_token == "csrf-query-token"
+    assert fake_get.calls[0]["params"] is None
+    assert fake_get.calls[0]["verify"] is False
+    assert fake_get.calls[0]["timeout"] == bdu.REQUEST_TIMEOUT
+    assert fake_get.calls[0]["headers"] == bdu.DEFAULT_HEADERS
+    assert fake_get.calls[0]["cookies"] is None
+
+
+def test_to_bdu_search_value_strips_cve_prefix():
+    assert bdu._to_bdu_search_value("CVE-2026-24017") == "2026-24017"
+    assert bdu._to_bdu_search_value("cve-2026-24017") == "2026-24017"
+    assert bdu._to_bdu_search_value("2026-24017") == "2026-24017"
+
+
+def test_extract_bdu_id_returns_none_when_selector_missing():
+    html = "<html><body><div id='vuls'></div></body></html>"
+    assert bdu._extract_bdu_id(html) is None
+
+
+def test_extract_bdu_id_returns_none_for_multiple_matches():
+        html = """
+        <div id="vuls">
+            <table class="table table-striped table-vuls">
+                <tr>
+                    <td class="col-lg-3 col-xs-3">
+                        <h4><a class="confirm-vul" href="/vul/one">BDU:2026-00001</a></h4>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-lg-3 col-xs-3">
+                        <h4><a class="confirm-vul" href="/vul/two">BDU:2026-00002</a></h4>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        """
+
+        assert bdu._extract_bdu_id(html) is None
+
+
+def test_extract_bdu_id_from_real_html_fixture():
+    html_path = Path(__file__).with_name("html.html")
+    html = html_path.read_text(encoding="utf-8")
+
+    assert bdu._extract_bdu_id(html) == "BDU:2026-03213"
+
+
+def test_extract_bdu_id_returns_none_for_real_notfound_fixture():
+    html_path = Path(__file__).with_name("html_notfound.html")
+    html = html_path.read_text(encoding="utf-8")
+
+    assert bdu._extract_bdu_id(html) is None


### PR DESCRIPTION
Closes #6

- Implement tests for `get_bdu_ids_by_cves` to validate correct mapping of CVEs to BDU IDs, handling of not found and failed requests.
- Create mock classes to simulate HTTP requests and responses.
- Test extraction of query tokens and CSRF tokens from cookies.
- Validate stripping of CVE prefixes and handling of HTML responses for BDU ID extraction.
- Include tests for real HTML fixtures to ensure accurate parsing of BDU IDs.