### PR TITLE
fix: correct SBOM/vuln dedup and honor generator/cert flags

### DIFF
--- a/src/sbom_pipeline/cli.py
+++ b/src/sbom_pipeline/cli.py
@@ -878,9 +878,14 @@ class ComponentType(str, Enum):
     device_driver = "device-driver"
     firmware = "firmware"
 
-def add_gost_cert_fields(sbom_path: Path, component_name: Optional[str] = None, component_version: Optional[str] = None,
-component_manufacturer: Optional[str] = None, component_type: ComponentType = ComponentType.application,
-output_path: Optional[Path] = None) -> Path:
+def add_gost_cert_fields(
+    sbom_path: Path,
+    component_name: Optional[str] = None,
+    component_version: Optional[str] = None,
+    component_manufacturer: Optional[str] = None,
+    component_type: ComponentType = ComponentType.application,
+    output_path: Optional[Path] = None,
+) -> Path:
    
     """Переработка структуры отчета согласно требованиям информационного сообщения ФСТЭК России
     от 13 января 2025 г. N 240/24/38."""

--- a/src/sbom_pipeline/dedup.py
+++ b/src/sbom_pipeline/dedup.py
@@ -5,10 +5,64 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
     from .vuln_merger import VulnFinding
+
+# Scalar CycloneDX component fields filled from a duplicate when target is empty.
+_COMPONENT_SCALAR_FIELDS = (
+    "cpe",
+    "description",
+    "purl",
+    "version",
+    "bom-ref",
+    "name",
+    "type",
+    "group",
+    "scope",
+    "copyright",
+    "publisher",
+    "author",
+    "supplier",
+    "mime-type",
+)
+
+
+def _normalize_purl(purl: str) -> str:
+    """Strip PURL qualifiers/subpath so Clair `?arch=` and plain purls match."""
+    if not purl:
+        return ""
+    base = purl.split("#", 1)[0]
+    return base.split("?", 1)[0]
+
+
+def _fallback_identity(comp: Dict[str, Any]) -> str:
+    """Stable identity when PURL is absent: type|group|name@version."""
+    ctype = str(comp.get("type") or "")
+    group = str(comp.get("group") or "")
+    name = str(comp.get("name") or "")
+    version = str(comp.get("version") or "")
+    return f"{ctype}|{group}|{name}@{version}"
+
+
+def _component_identity(comp: Dict[str, Any]) -> Optional[str]:
+    """
+    Canonical dedup key for a component.
+
+    Prefer normalized PURL. Fall back to type|group|name@version.
+    Return None when there is no usable identity (do not merge anonymously).
+    """
+    purl = _normalize_purl(str(comp.get("purl") or ""))
+    if purl:
+        return f"purl:{purl}"
+
+    name = str(comp.get("name") or "")
+    version = str(comp.get("version") or "")
+    if not name and not version:
+        return None
+
+    return f"nv:{_fallback_identity(comp)}"
 
 
 def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
@@ -36,7 +90,7 @@ def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
                 existing.add(key)
 
     # --- скалярные поля (заполняем только если у target пусто) ---
-    for field in ("cpe", "description", "purl", "version", "bom-ref", "name", "type"):
+    for field in _COMPONENT_SCALAR_FIELDS:
         if not target.get(field) and source.get(field):
             target[field] = source[field]
 
@@ -52,31 +106,73 @@ def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
                 target.setdefault("licenses", []).append(lic)
                 existing_lic.add(k)
 
-    # --- hashes (union by alg) ---
+    # --- hashes (union by alg+content; conflicting digests are retained) ---
     if source.get("hashes"):
-        existing_algs: Dict[str, Any] = {
-            str(h["alg"]): h
+        existing_hashes: set[tuple[str, str]] = {
+            (str(h.get("alg", "")), str(h.get("content", "")))
             for h in (target.get("hashes") or [])
-            if isinstance(h, dict) and h.get("alg") is not None
+            if isinstance(h, dict)
         }
         for h in source["hashes"]:
-            if isinstance(h, dict) and h.get("alg") is not None:
-                alg = str(h["alg"])
-                if alg not in existing_algs:
-                    target.setdefault("hashes", []).append(h)
-                    existing_algs[alg] = h
+            if not isinstance(h, dict):
+                continue
+            key = (str(h.get("alg", "")), str(h.get("content", "")))
+            if key not in existing_hashes:
+                target.setdefault("hashes", []).append(h)
+                existing_hashes.add(key)
 
-    # --- externalReferences (union by url) ---
+    # --- externalReferences (union by url+type) ---
     if source.get("externalReferences"):
-        existing_urls: set = {
-            r.get("url")
+        existing_refs: set[tuple[Any, Any]] = {
+            (r.get("url"), r.get("type"))
             for r in (target.get("externalReferences") or [])
             if isinstance(r, dict)
         }
         for ref in source["externalReferences"]:
-            if isinstance(ref, dict) and ref.get("url") not in existing_urls:
+            if not isinstance(ref, dict):
+                continue
+            key = (ref.get("url"), ref.get("type"))
+            if key not in existing_refs:
                 target.setdefault("externalReferences", []).append(ref)
-                existing_urls.add(ref.get("url"))
+                existing_refs.add(key)
+
+    # --- nested components: append unique by identity ---
+    if source.get("components"):
+        target_nested = target.setdefault("components", [])
+        nested_keys = {
+            _component_identity(c)
+            for c in target_nested
+            if isinstance(c, dict) and _component_identity(c)
+        }
+        for child in source["components"]:
+            if not isinstance(child, dict):
+                target_nested.append(child)
+                continue
+            child_key = _component_identity(child)
+            if child_key and child_key in nested_keys:
+                continue
+            target_nested.append(child)
+            if child_key:
+                nested_keys.add(child_key)
+
+
+def _apply_ref(value: Any, ref_map: Dict[str, str]) -> Any:
+    if isinstance(value, str):
+        return ref_map.get(value, value)
+    return value
+
+
+def _remap_ref_list(values: List[Any], ref_map: Dict[str, str]) -> List[Any]:
+    remapped: list[Any] = []
+    seen: set[str] = set()
+    for value in values:
+        new_val = _apply_ref(value, ref_map)
+        marker = new_val if isinstance(new_val, str) else json.dumps(new_val, sort_keys=True)
+        if marker in seen:
+            continue
+        seen.add(str(marker))
+        remapped.append(new_val)
+    return remapped
 
 
 def _remap_dependencies(
@@ -95,42 +191,56 @@ def _remap_dependencies(
             continue
 
         raw_ref = dep.get("ref")
-        ref = ref_map.get(raw_ref, raw_ref) if raw_ref else raw_ref
+        ref = _apply_ref(raw_ref, ref_map) if raw_ref else raw_ref
 
-        depends_on: list[Any] = []
-        for child in dep.get("dependsOn") or []:
-            depends_on.append(ref_map.get(child, child) if isinstance(child, str) else child)
+        depends_on = _remap_ref_list(list(dep.get("dependsOn") or []), ref_map)
+        # Drop self-edges introduced when a duplicate depended on the survivor
+        if isinstance(ref, str):
+            depends_on = [c for c in depends_on if c != ref]
+
+        provides = _remap_ref_list(list(dep.get("provides") or []), ref_map)
 
         if not ref:
-            entry = {k: v for k, v in dep.items() if k != "dependsOn"}
+            entry = {k: v for k, v in dep.items() if k not in ("dependsOn", "provides")}
             if depends_on:
-                # de-dupe while preserving order
-                seen_child: set[str] = set()
-                unique_children: list[Any] = []
-                for child in depends_on:
-                    key = child if isinstance(child, str) else json.dumps(child, sort_keys=True)
-                    if key not in seen_child:
-                        seen_child.add(str(key))
-                        unique_children.append(child)
-                entry["dependsOn"] = unique_children
+                entry["dependsOn"] = depends_on
+            if provides:
+                entry["provides"] = provides
             merged.append(entry)
             continue
 
-        current = by_ref.get(ref)
+        current = by_ref.get(str(ref))
         if current is None:
-            current = {"ref": ref, "dependsOn": []}
-            by_ref[ref] = current
+            current = {k: v for k, v in dep.items() if k not in ("ref", "dependsOn", "provides")}
+            current["ref"] = ref
+            current["dependsOn"] = []
+            if provides:
+                current["provides"] = list(provides)
+            by_ref[str(ref)] = current
             merged.append(current)
+        else:
+            # Merge extra fields that the first entry lacked
+            for key, value in dep.items():
+                if key in ("ref", "dependsOn", "provides"):
+                    continue
+                if key not in current and value:
+                    current[key] = value
+            if provides:
+                existing_provides = current.setdefault("provides", [])
+                for item in provides:
+                    if item not in existing_provides:
+                        existing_provides.append(item)
 
         existing_children = current.setdefault("dependsOn", [])
         for child in depends_on:
             if child not in existing_children:
                 existing_children.append(child)
 
-    # Drop empty dependsOn arrays for cleaner CycloneDX
     for entry in merged:
         if isinstance(entry, dict) and not entry.get("dependsOn"):
             entry.pop("dependsOn", None)
+        if isinstance(entry, dict) and not entry.get("provides"):
+            entry.pop("provides", None)
 
     return merged
 
@@ -150,44 +260,158 @@ def _remap_vulnerability_refs(
                 affect["ref"] = ref_map[affect["ref"]]
 
 
+def _remap_compositions(
+    compositions: List[Any],
+    ref_map: Dict[str, str],
+) -> None:
+    """Переписать bom-ref внутри compositions (assemblies / dependencies / vulnerabilities)."""
+    if not ref_map:
+        return
+    for composition in compositions:
+        if not isinstance(composition, dict):
+            continue
+        for field in ("assemblies", "dependencies", "vulnerabilities"):
+            values = composition.get(field)
+            if isinstance(values, list):
+                composition[field] = _remap_ref_list(values, ref_map)
+
+
+def _register_aliases(
+    identity_to_key: Dict[str, str],
+    name_ver_to_key: Dict[str, str],
+    key: str,
+    comp: Dict[str, Any],
+) -> None:
+    """Index a kept component under all identities that should resolve to it."""
+    identity_to_key[key] = key
+    purl = _normalize_purl(str(comp.get("purl") or ""))
+    if purl:
+        identity_to_key[f"purl:{purl}"] = key
+
+    name = str(comp.get("name") or "")
+    version = str(comp.get("version") or "")
+    if not (name or version):
+        return
+
+    identity_to_key[f"nv:{_fallback_identity(comp)}"] = key
+    name_ver = f"{name}@{version}"
+    # Prefer a PURL-backed entry for the plain name@version index.
+    if purl or name_ver not in name_ver_to_key:
+        name_ver_to_key[name_ver] = key
+
+
+def _resolve_existing_key(
+    comp: Dict[str, Any],
+    identity: str,
+    identity_to_key: Dict[str, str],
+    name_ver_to_key: Dict[str, str],
+    seen: Dict[str, Dict[str, Any]],
+) -> Optional[str]:
+    """Find the canonical key of an already-seen duplicate, if any."""
+    key = identity_to_key.get(identity)
+    if key is not None:
+        return key
+
+    name = str(comp.get("name") or "")
+    version = str(comp.get("version") or "")
+    name_ver = f"{name}@{version}"
+    has_purl = bool(_normalize_purl(str(comp.get("purl") or "")))
+
+    if not has_purl:
+        # no-PURL may join an earlier PURL twin; do not collapse two no-PURL
+        # components that only share name@version but differ by group/type.
+        prior = name_ver_to_key.get(name_ver)
+        if prior is not None and _normalize_purl(str(seen[prior].get("purl") or "")):
+            return prior
+        return None
+
+    # PURL joins an earlier no-PURL twin (exact type|group|name@version first)
+    prior = identity_to_key.get(f"nv:{_fallback_identity(comp)}")
+    if prior is not None and not _normalize_purl(str(seen[prior].get("purl") or "")):
+        return prior
+
+    prior = name_ver_to_key.get(name_ver)
+    if prior is not None and not _normalize_purl(str(seen[prior].get("purl") or "")):
+        return prior
+
+    return None
+
+
+def _record_ref_map(
+    ref_map: Dict[str, str],
+    discarded_ref: Any,
+    kept_ref: Any,
+) -> None:
+    if discarded_ref and kept_ref and discarded_ref != kept_ref:
+        ref_map[str(discarded_ref)] = str(kept_ref)
+
+
 def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     """
     Дедуплицировать компоненты CycloneDX SBOM по ключу PURL.
 
-    Если PURL отсутствует, ключом служит «name@version».
-    При обнаружении дублей все полезные данные (properties, cpe, hashes,
-    licenses, externalReferences) объединяются в одну запись, чтобы не
-    потерять сведения из разных источников (cdxgen, Clair и т.д.).
+    Если PURL отсутствует, ключом служит «type|group|name@version».
+    PURL сравниваются без qualifiers (`?arch=` и т.п.), чтобы Clair и
+    генераторы склеивали один и тот же пакет.
 
-    Ссылки bom-ref в dependencies / vulnerabilities.affects переписываются
-    на канонический ref оставшегося компонента.
+    При обнаружении дублей все полезные данные (properties, cpe, hashes,
+    licenses, externalReferences, supplier, …) объединяются в одну запись.
+
+    Ссылки bom-ref в dependencies / compositions / vulnerabilities.affects
+    переписываются на канонический ref оставшегося компонента.
     """
     with open(input_path, encoding="utf-8") as f:
         sbom: Dict[str, Any] = json.load(f)
 
     components = sbom.get("components", [])
+    if not isinstance(components, list):
+        components = []
+
     seen: Dict[str, Dict[str, Any]] = {}
     order: list[str] = []
     ref_map: Dict[str, str] = {}
+    identity_to_key: Dict[str, str] = {}
+    name_ver_to_key: Dict[str, str] = {}
+    passthrough: list[Any] = []
+    anonymous_idx = 0
 
     for comp in components:
         if not isinstance(comp, dict):
+            passthrough.append(comp)
             continue
-        purl = comp.get("purl", "")
-        key = purl if purl else f"{comp.get('name', '')}@{comp.get('version', '')}"
-        if key not in seen:
+
+        identity = _component_identity(comp)
+        if identity is None:
+            bom_ref = comp.get("bom-ref")
+            anon_key = f"anon-ref:{bom_ref}" if bom_ref else f"anon:{anonymous_idx}"
+            if not bom_ref:
+                anonymous_idx += 1
+            if anon_key not in seen:
+                seen[anon_key] = comp
+                order.append(anon_key)
+            else:
+                kept = seen[anon_key]
+                _merge_component(kept, comp)
+                _record_ref_map(ref_map, comp.get("bom-ref"), kept.get("bom-ref"))
+            continue
+
+        key = _resolve_existing_key(
+            comp, identity, identity_to_key, name_ver_to_key, seen
+        )
+        if key is None:
+            key = identity
             seen[key] = comp
             order.append(key)
-        else:
-            kept = seen[key]
-            discarded_ref = comp.get("bom-ref")
-            # Merge first so kept may gain a bom-ref from the duplicate
-            _merge_component(kept, comp)
-            kept_ref = kept.get("bom-ref")
-            if discarded_ref and kept_ref and discarded_ref != kept_ref:
-                ref_map[str(discarded_ref)] = str(kept_ref)
+            _register_aliases(identity_to_key, name_ver_to_key, key, comp)
+            continue
 
-    deduped = [seen[k] for k in order]
+        kept = seen[key]
+        discarded_ref = comp.get("bom-ref")
+        _merge_component(kept, comp)
+        _record_ref_map(ref_map, discarded_ref, kept.get("bom-ref"))
+        _register_aliases(identity_to_key, name_ver_to_key, key, kept)
+
+    deduped = [seen[k] for k in order] + passthrough
     removed = len(components) - len(deduped)
     logging.info(
         f"[dedup] {len(components)} → {len(deduped)} компонентов (удалено {removed} дублей)"
@@ -200,9 +424,10 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
             sbom["dependencies"] = _remap_dependencies(sbom["dependencies"], ref_map)
         if isinstance(sbom.get("vulnerabilities"), list):
             _remap_vulnerability_refs(sbom["vulnerabilities"], ref_map)
+        if isinstance(sbom.get("compositions"), list):
+            _remap_compositions(sbom["compositions"], ref_map)
         logging.debug(f"[dedup] Переписано bom-ref: {len(ref_map)} ссылок")
 
-    # Пересчитать metadata.component count если есть
     if "metadata" in sbom and isinstance(sbom["metadata"].get("component"), dict):
         pass  # не трогаем — cdxgen управляет metadata.component
 
@@ -217,7 +442,7 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
 def _component_key(f: "VulnFinding", name_ver_to_purl: Dict[str, str]) -> str:
     """Канонический ключ компонента: PURL, иначе name@version (с подстановкой PURL)."""
     if f.component_purl:
-        return f.component_purl
+        return _normalize_purl(f.component_purl)
     name_ver = f"{f.component_name}@{f.component_version}"
     return name_ver_to_purl.get(name_ver, name_ver)
 
@@ -260,7 +485,9 @@ def dedup_vulns(findings: List["VulnFinding"]) -> List["VulnFinding"]:
     name_ver_to_purl: dict[str, str] = {}
     for f in findings:
         if f.component_purl:
-            name_ver_to_purl[f"{f.component_name}@{f.component_version}"] = f.component_purl
+            name_ver_to_purl[f"{f.component_name}@{f.component_version}"] = _normalize_purl(
+                f.component_purl
+            )
 
     best: dict[str, "VulnFinding"] = {}
 

--- a/src/sbom_pipeline/dedup.py
+++ b/src/sbom_pipeline/dedup.py
@@ -123,18 +123,18 @@ def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
 
     # --- externalReferences (union by url+type) ---
     if source.get("externalReferences"):
-        existing_refs: set[tuple[Any, Any]] = {
-            (r.get("url"), r.get("type"))
+        existing_refs: set[tuple[str, str]] = {
+            (str(r.get("url") or ""), str(r.get("type") or ""))
             for r in (target.get("externalReferences") or [])
             if isinstance(r, dict)
         }
         for ref in source["externalReferences"]:
             if not isinstance(ref, dict):
                 continue
-            key = (ref.get("url"), ref.get("type"))
-            if key not in existing_refs:
+            ref_key = (str(ref.get("url") or ""), str(ref.get("type") or ""))
+            if ref_key not in existing_refs:
                 target.setdefault("externalReferences", []).append(ref)
-                existing_refs.add(key)
+                existing_refs.add(ref_key)
 
     # --- nested components: append unique by identity ---
     if source.get("components"):

--- a/src/sbom_pipeline/dedup.py
+++ b/src/sbom_pipeline/dedup.py
@@ -19,25 +19,24 @@ def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
     из нескольких источников (cdxgen + Clair и т.п.), все полезные
     свойства объединяются в одну запись.
     """
-    # --- properties (union by name; предпочитаем непустое значение) ---
+    # --- properties (union by name+value; CycloneDX допускает повторы имён) ---
     if source.get("properties"):
         target_props: List[Dict[str, str]] = target.setdefault("properties", [])
-        by_name: Dict[str, Dict[str, str]] = {
-            p.get("name", ""): p for p in target_props if isinstance(p, dict)
+        existing: set[tuple[str, str]] = {
+            (str(p.get("name", "")), str(p.get("value", "")))
+            for p in target_props
+            if isinstance(p, dict)
         }
         for prop in source["properties"]:
             if not isinstance(prop, dict):
                 continue
-            pname = prop.get("name", "")
-            pval = prop.get("value", "")
-            if pname not in by_name:
+            key = (str(prop.get("name", "")), str(prop.get("value", "")))
+            if key not in existing:
                 target_props.append(prop)
-                by_name[pname] = prop
-            elif not by_name[pname].get("value") and pval:
-                by_name[pname]["value"] = pval
+                existing.add(key)
 
     # --- скалярные поля (заполняем только если у target пусто) ---
-    for field in ("cpe", "description", "purl", "version", "bom-ref"):
+    for field in ("cpe", "description", "purl", "version", "bom-ref", "name", "type"):
         if not target.get(field) and source.get(field):
             target[field] = source[field]
 
@@ -80,6 +79,77 @@ def _merge_component(target: Dict[str, Any], source: Dict[str, Any]) -> None:
                 existing_urls.add(ref.get("url"))
 
 
+def _remap_dependencies(
+    dependencies: List[Any],
+    ref_map: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Переписать dependencies с учётом слитых bom-ref и объединить по ref."""
+    if not dependencies:
+        return []
+
+    merged: list[dict[str, Any]] = []
+    by_ref: dict[str, dict[str, Any]] = {}
+
+    for dep in dependencies:
+        if not isinstance(dep, dict):
+            continue
+
+        raw_ref = dep.get("ref")
+        ref = ref_map.get(raw_ref, raw_ref) if raw_ref else raw_ref
+
+        depends_on: list[Any] = []
+        for child in dep.get("dependsOn") or []:
+            depends_on.append(ref_map.get(child, child) if isinstance(child, str) else child)
+
+        if not ref:
+            entry = {k: v for k, v in dep.items() if k != "dependsOn"}
+            if depends_on:
+                # de-dupe while preserving order
+                seen_child: set[str] = set()
+                unique_children: list[Any] = []
+                for child in depends_on:
+                    key = child if isinstance(child, str) else json.dumps(child, sort_keys=True)
+                    if key not in seen_child:
+                        seen_child.add(str(key))
+                        unique_children.append(child)
+                entry["dependsOn"] = unique_children
+            merged.append(entry)
+            continue
+
+        current = by_ref.get(ref)
+        if current is None:
+            current = {"ref": ref, "dependsOn": []}
+            by_ref[ref] = current
+            merged.append(current)
+
+        existing_children = current.setdefault("dependsOn", [])
+        for child in depends_on:
+            if child not in existing_children:
+                existing_children.append(child)
+
+    # Drop empty dependsOn arrays for cleaner CycloneDX
+    for entry in merged:
+        if isinstance(entry, dict) and not entry.get("dependsOn"):
+            entry.pop("dependsOn", None)
+
+    return merged
+
+
+def _remap_vulnerability_refs(
+    vulnerabilities: List[Any],
+    ref_map: Dict[str, str],
+) -> None:
+    """Обновить affects[].ref у существующих уязвимостей после слияния компонентов."""
+    if not ref_map:
+        return
+    for vuln in vulnerabilities:
+        if not isinstance(vuln, dict):
+            continue
+        for affect in vuln.get("affects") or []:
+            if isinstance(affect, dict) and affect.get("ref") in ref_map:
+                affect["ref"] = ref_map[affect["ref"]]
+
+
 def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     """
     Дедуплицировать компоненты CycloneDX SBOM по ключу PURL.
@@ -88,6 +158,9 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     При обнаружении дублей все полезные данные (properties, cpe, hashes,
     licenses, externalReferences) объединяются в одну запись, чтобы не
     потерять сведения из разных источников (cdxgen, Clair и т.д.).
+
+    Ссылки bom-ref в dependencies / vulnerabilities.affects переписываются
+    на канонический ref оставшегося компонента.
     """
     with open(input_path, encoding="utf-8") as f:
         sbom: Dict[str, Any] = json.load(f)
@@ -95,16 +168,24 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     components = sbom.get("components", [])
     seen: Dict[str, Dict[str, Any]] = {}
     order: list[str] = []
+    ref_map: Dict[str, str] = {}
 
     for comp in components:
+        if not isinstance(comp, dict):
+            continue
         purl = comp.get("purl", "")
         key = purl if purl else f"{comp.get('name', '')}@{comp.get('version', '')}"
         if key not in seen:
             seen[key] = comp
             order.append(key)
         else:
-            # Дубль — перенести все полезные данные из comp в уже сохранённый
-            _merge_component(seen[key], comp)
+            kept = seen[key]
+            discarded_ref = comp.get("bom-ref")
+            # Merge first so kept may gain a bom-ref from the duplicate
+            _merge_component(kept, comp)
+            kept_ref = kept.get("bom-ref")
+            if discarded_ref and kept_ref and discarded_ref != kept_ref:
+                ref_map[str(discarded_ref)] = str(kept_ref)
 
     deduped = [seen[k] for k in order]
     removed = len(components) - len(deduped)
@@ -113,6 +194,13 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     )
 
     sbom["components"] = deduped
+
+    if ref_map:
+        if isinstance(sbom.get("dependencies"), list):
+            sbom["dependencies"] = _remap_dependencies(sbom["dependencies"], ref_map)
+        if isinstance(sbom.get("vulnerabilities"), list):
+            _remap_vulnerability_refs(sbom["vulnerabilities"], ref_map)
+        logging.debug(f"[dedup] Переписано bom-ref: {len(ref_map)} ссылок")
 
     # Пересчитать metadata.component count если есть
     if "metadata" in sbom and isinstance(sbom["metadata"].get("component"), dict):
@@ -126,25 +214,66 @@ def dedup_sbom(input_path: Path, output_path: Path) -> Path:
     return output_path
 
 
+def _component_key(f: "VulnFinding", name_ver_to_purl: Dict[str, str]) -> str:
+    """Канонический ключ компонента: PURL, иначе name@version (с подстановкой PURL)."""
+    if f.component_purl:
+        return f.component_purl
+    name_ver = f"{f.component_name}@{f.component_version}"
+    return name_ver_to_purl.get(name_ver, name_ver)
+
+
+def _merge_finding_fields(target: "VulnFinding", source: "VulnFinding") -> None:
+    """Дополнить выбранную запись непустыми полями из дубликата."""
+    if not target.fixed_version and source.fixed_version:
+        target.fixed_version = source.fixed_version
+    if not target.recommendation and source.recommendation:
+        target.recommendation = source.recommendation
+    if not target.acceptability_status and source.acceptability_status:
+        target.acceptability_status = source.acceptability_status
+    if not target.description and source.description:
+        target.description = source.description
+    if not target.bdu_id and source.bdu_id:
+        target.bdu_id = source.bdu_id
+    if not target.component_purl and source.component_purl:
+        target.component_purl = source.component_purl
+    # Prefer a more informative severity when current is UNKNOWN/empty
+    if (not target.severity or target.severity.upper() == "UNKNOWN") and source.severity:
+        target.severity = source.severity
+
+
 def dedup_vulns(findings: List["VulnFinding"]) -> List["VulnFinding"]:
     """
     Дедуплицировать список VulnFinding по ключу «CVE-ID :: компонент».
 
     Если несколько сканеров обнаружили одну и ту же уязвимость в одном
     компоненте — оставляем запись с наибольшим cvss_score; при равном
-    балле — первую встреченную.
+    балле — первую встреченную. Непустые поля (fixed_version, recommendation
+    и т.д.) из остальных дублей переносятся в выбранную запись.
+
+    Finding без PURL сопоставляется с finding, у которого есть PURL при
+    совпадении name@version (типичный случай Clair + Trivy).
 
     После дедупликации заполняем cvss_score == 0.0 используя лучший
     известный балл для этого CVE из других компонентов (cross-component
     propagation).
     """
+    name_ver_to_purl: dict[str, str] = {}
+    for f in findings:
+        if f.component_purl:
+            name_ver_to_purl[f"{f.component_name}@{f.component_version}"] = f.component_purl
+
     best: dict[str, "VulnFinding"] = {}
 
     for f in findings:
-        comp_key = f.component_purl if f.component_purl else f"{f.component_name}@{f.component_version}"
+        comp_key = _component_key(f, name_ver_to_purl)
         key = f"{f.cve_id}::{comp_key}"
-        if key not in best or f.cvss_score > best[key].cvss_score:
+        if key not in best:
             best[key] = f
+        elif f.cvss_score > best[key].cvss_score:
+            _merge_finding_fields(f, best[key])
+            best[key] = f
+        else:
+            _merge_finding_fields(best[key], f)
 
     deduped = list(best.values())
     removed = len(findings) - len(deduped)

--- a/src/sbom_pipeline/pipeline.py
+++ b/src/sbom_pipeline/pipeline.py
@@ -278,6 +278,9 @@ def gen_sbom(cfg: PipelineConfig) -> None:
             "и/или --image --clair (образ контейнера)."
         )
 
+    if _has_code and not cfg.use_cdxgen and not cfg.use_syft:
+        raise ValueError("Нужно включить хотя бы один генератор SBOM: cdxgen или syft.")
+
     if _has_code:
         if cfg.source in ("github", "gitlab"):
             if not cfg.git_url:
@@ -363,9 +366,6 @@ def run(cfg: PipelineConfig) -> None:
     """Запустить полный пайплайн."""
     cfg.ensure_output_dirs()
 
-    if not cfg.use_cdxgen and not cfg.use_syft:
-        raise ValueError("Нужно включить хотя бы один генератор SBOM: cdxgen или syft.")
-
     # ------------------------------------------------------------------
     # 1. Генерация SBOM
     # ------------------------------------------------------------------
@@ -381,6 +381,9 @@ def run(cfg: PipelineConfig) -> None:
             "Не задан ни один источник. Укажите --path/--url (исходный код) "
             "и/или --image --clair (образ контейнера)."
         )
+
+    if _has_code and not cfg.use_cdxgen and not cfg.use_syft:
+        raise ValueError("Нужно включить хотя бы один генератор SBOM: cdxgen или syft.")
 
     if _has_code:
         if cfg.source in ("github", "gitlab"):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -164,6 +164,66 @@ def test_dedup_removes_duplicates():
         assert len(result["components"]) == 2
 
 
+def test_dedup_sbom_remaps_dependency_refs():
+    """Discarded bom-refs must be rewritten in dependencies."""
+    sbom = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "components": [
+            {
+                "type": "library",
+                "name": "requests",
+                "version": "2.31.0",
+                "purl": "pkg:pypi/requests@2.31.0",
+                "bom-ref": "r1",
+                "properties": [{"name": "src", "value": "cdxgen"}],
+            },
+            {
+                "type": "library",
+                "name": "requests",
+                "version": "2.31.0",
+                "purl": "pkg:pypi/requests@2.31.0",
+                "bom-ref": "r2",
+                "properties": [{"name": "src", "value": "syft"}],
+                "cpe": "cpe:2.3:a:python:requests:2.31.0:*:*:*:*:*:*:*",
+            },
+            {
+                "type": "library",
+                "name": "flask",
+                "version": "3.0.0",
+                "purl": "pkg:pypi/flask@3.0.0",
+                "bom-ref": "f1",
+            },
+        ],
+        "dependencies": [
+            {"ref": "app", "dependsOn": ["r1", "r2", "f1"]},
+            {"ref": "r2", "dependsOn": ["f1"]},
+        ],
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp)
+        inp = p / "bom.json"
+        out = p / "bom-dedup.json"
+        inp.write_text(json.dumps(sbom))
+
+        dedup_sbom(inp, out)
+        result = json.loads(out.read_text())
+
+        assert len(result["components"]) == 2
+        kept = next(c for c in result["components"] if c["name"] == "requests")
+        assert kept["bom-ref"] == "r1"
+        assert kept["cpe"].startswith("cpe:")
+        # Both distinct property values preserved
+        prop_values = {(pr["name"], pr["value"]) for pr in kept["properties"]}
+        assert ("src", "cdxgen") in prop_values
+        assert ("src", "syft") in prop_values
+
+        deps_by_ref = {d["ref"]: d for d in result["dependencies"]}
+        assert deps_by_ref["app"]["dependsOn"] == ["r1", "f1"]
+        assert "r2" not in deps_by_ref
+        assert deps_by_ref["r1"]["dependsOn"] == ["f1"]
+
+
 def test_generate_from_dir_requires_enabled_generator():
     with tempfile.TemporaryDirectory() as tmp:
         p = Path(tmp)
@@ -518,22 +578,34 @@ def test_dedup_vulns_fallback_key_no_purl():
     assert len(result) == 1
 
 
-def test_dedup_vulns_no_cross_match_purl_vs_nopurl():
-    """A finding with purl and one without for the same name@version are distinct keys."""
-    f1 = _vuln("CVE-2023-5555", "pkg:pypi/lib@1.0", 5.0)
+def test_dedup_vulns_cross_match_purl_vs_nopurl():
+    """Clair (no purl) and Trivy (purl) for the same name@version collapse to one."""
+    f1 = VulnFinding(
+        cve_id="CVE-2023-5555",
+        component_name="lib",
+        component_version="1.0",
+        component_purl="pkg:pypi/lib@1.0",
+        cvss_score=5.0,
+        severity="HIGH",
+        description="test",
+        scanner="trivy",
+    )
     f2 = VulnFinding(
         cve_id="CVE-2023-5555",
         component_name="lib",
         component_version="1.0",
         component_purl="",
-        cvss_score=5.0,
+        cvss_score=0.0,
         severity="HIGH",
         description="",
         scanner="clair",
+        fixed_version="1.0.1",
     )
-    # Different keys → both kept (purl vs name@version)
     result = dedup_vulns([f1, f2])
-    assert len(result) == 2
+    assert len(result) == 1
+    assert result[0].component_purl == "pkg:pypi/lib@1.0"
+    assert result[0].fixed_version == "1.0.1"
+    assert result[0].cvss_score == 5.0
 
 
 def test_format_sboms_skips_non_sbom_json():
@@ -1249,3 +1321,4 @@ def test_format_extracts_vulnerabilities_from_sbom(tmp_path):
     assert "Уязвимости" in wb.sheetnames
     rows = list(wb["Уязвимости"].iter_rows(values_only=True))
     assert any("CVE-2020-0001" in str(c) for r in rows for c in r), "уязвимость должна быть в Excel"
+

--- a/tests/unit/sbom_pipeline/test_dedup_sbom.py
+++ b/tests/unit/sbom_pipeline/test_dedup_sbom.py
@@ -1,0 +1,203 @@
+"""Unit tests for component-level SBOM deduplication (dedup_sbom)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sbom_pipeline.dedup import dedup_sbom
+
+
+def _run(sbom: dict, tmp_path: Path) -> dict:
+    inp = tmp_path / "in.json"
+    out = tmp_path / "out.json"
+    inp.write_text(json.dumps(sbom), encoding="utf-8")
+    dedup_sbom(inp, out)
+    return json.loads(out.read_text(encoding="utf-8"))
+
+
+def test_same_purl_deduped(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r1"},
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r2"},
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 1
+    assert result["components"][0]["bom-ref"] == "r1"
+
+
+def test_purl_with_arch_qualifier_matches_plain_purl(tmp_path):
+    """Clair `?arch=` must collapse with generator purl without qualifiers."""
+    sbom = {
+        "components": [
+            {
+                "type": "library",
+                "name": "curl",
+                "version": "8.0",
+                "purl": "pkg:deb/debian/curl@8.0",
+                "bom-ref": "syft-curl",
+            },
+            {
+                "type": "library",
+                "name": "curl",
+                "version": "8.0",
+                "purl": "pkg:deb/debian/curl@8.0?arch=amd64",
+                "bom-ref": "pkg:deb/debian/curl@8.0?arch=amd64",
+                "properties": [{"name": "container_image", "value": "img:1"}],
+                "cpe": "cpe:2.3:a:haxx:curl:8.0:*:*:*:*:*:*:*",
+            },
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 1
+    kept = result["components"][0]
+    assert kept["cpe"].startswith("cpe:")
+    assert any(p["name"] == "container_image" for p in kept["properties"])
+
+
+def test_nopurl_matches_purl_same_name_version(tmp_path):
+    sbom = {
+        "components": [
+            {
+                "type": "library",
+                "name": "requests",
+                "version": "2.31.0",
+                "purl": "pkg:pypi/requests@2.31.0",
+                "bom-ref": "with-purl",
+            },
+            {
+                "type": "library",
+                "name": "requests",
+                "version": "2.31.0",
+                "bom-ref": "no-purl",
+                "supplier": {"name": "PSF"},
+            },
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 1
+    kept = result["components"][0]
+    assert kept["purl"] == "pkg:pypi/requests@2.31.0"
+    assert kept["supplier"] == {"name": "PSF"}
+
+
+def test_different_groups_without_purl_kept_separate(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "group": "org.a", "name": "core", "version": "1", "bom-ref": "a"},
+            {"type": "library", "group": "org.b", "name": "core", "version": "1", "bom-ref": "b"},
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 2
+
+
+def test_anonymous_components_not_collapsed(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "file", "bom-ref": "a"},
+            {"type": "file", "bom-ref": "b"},
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 2
+
+
+def test_non_dict_components_preserved(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r1"},
+            "not-a-component",
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 2
+    assert result["components"][1] == "not-a-component"
+
+
+def test_conflicting_hashes_retained(tmp_path):
+    sbom = {
+        "components": [
+            {
+                "type": "library",
+                "name": "a",
+                "version": "1",
+                "purl": "pkg:pypi/a@1",
+                "bom-ref": "r1",
+                "hashes": [{"alg": "SHA-256", "content": "aaa"}],
+            },
+            {
+                "type": "library",
+                "name": "a",
+                "version": "1",
+                "purl": "pkg:pypi/a@1",
+                "bom-ref": "r2",
+                "hashes": [{"alg": "SHA-256", "content": "bbb"}],
+            },
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    contents = {h["content"] for h in result["components"][0]["hashes"]}
+    assert contents == {"aaa", "bbb"}
+
+
+def test_dependencies_provides_preserved_and_self_edge_removed(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r1"},
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r2"},
+        ],
+        "dependencies": [
+            {"ref": "r2", "dependsOn": ["r1"], "provides": ["cap-a"]},
+            {"ref": "app", "dependsOn": ["r1", "r2"]},
+        ],
+    }
+    result = _run(sbom, tmp_path)
+    deps = {d["ref"]: d for d in result["dependencies"]}
+    assert "r2" not in deps
+    assert deps["r1"]["provides"] == ["cap-a"]
+    assert "dependsOn" not in deps["r1"]  # self-edge r2→r1 collapsed away
+    assert deps["app"]["dependsOn"] == ["r1"]
+
+
+def test_compositions_refs_remapped(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r1"},
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r2"},
+        ],
+        "compositions": [
+            {"assemblies": ["r2"], "dependencies": ["r1", "r2"]},
+        ],
+    }
+    result = _run(sbom, tmp_path)
+    comp = result["compositions"][0]
+    assert comp["assemblies"] == ["r1"]
+    assert comp["dependencies"] == ["r1"]
+
+
+def test_vulnerability_affects_remapped(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r1"},
+            {"type": "library", "name": "a", "version": "1", "purl": "pkg:pypi/a@1", "bom-ref": "r2"},
+        ],
+        "vulnerabilities": [
+            {"id": "CVE-1", "affects": [{"ref": "r2"}]},
+        ],
+    }
+    result = _run(sbom, tmp_path)
+    assert result["vulnerabilities"][0]["affects"][0]["ref"] == "r1"
+
+
+def test_different_purls_same_name_version_kept_separate(tmp_path):
+    sbom = {
+        "components": [
+            {"type": "library", "name": "foo", "version": "1.0", "purl": "pkg:pypi/foo@1.0", "bom-ref": "py"},
+            {"type": "library", "name": "foo", "version": "1.0", "purl": "pkg:npm/foo@1.0", "bom-ref": "js"},
+        ]
+    }
+    result = _run(sbom, tmp_path)
+    assert len(result["components"]) == 2

--- a/tests/unit/sbom_pipeline/test_dedup_vulns.py
+++ b/tests/unit/sbom_pipeline/test_dedup_vulns.py
@@ -177,21 +177,74 @@ class TestFallbackKey:
         )
         assert len(dedup_vulns([f1, f2])) == 2
 
-    def test_purl_and_nopurl_are_distinct_keys(self):
-        """Finding with purl and one without (same name@version) are different keys."""
+    def test_purl_and_nopurl_same_name_version_deduped(self):
+        """Clair (no purl) + Trivy (with purl) for same name@version → one finding."""
         f_with_purl = _f("CVE-2024-6666", "pkg:pypi/lib@1.0", name="lib", version="1.0")
         f_no_purl = VulnFinding(
             cve_id="CVE-2024-6666",
             component_name="lib",
             component_version="1.0",
             component_purl="",
-            cvss_score=5.0,
+            cvss_score=0.0,
             severity="HIGH",
             description="",
             scanner="clair",
+            fixed_version="1.0.1",
         )
-        # purl key ≠ name@version key → both survive
-        assert len(dedup_vulns([f_with_purl, f_no_purl])) == 2
+        result = dedup_vulns([f_with_purl, f_no_purl])
+        assert len(result) == 1
+        assert result[0].component_purl == "pkg:pypi/lib@1.0"
+        assert result[0].fixed_version == "1.0.1"
+        assert result[0].cvss_score == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Field merge when higher CVSS wins
+# ---------------------------------------------------------------------------
+
+class TestFieldMerge:
+    def test_higher_score_keeps_fixed_version_from_loser(self):
+        findings = [
+            _f("CVE-2024-7777", "pkg:pypi/a@1.0", 9.0, "trivy"),
+            VulnFinding(
+                cve_id="CVE-2024-7777",
+                component_name="a",
+                component_version="1.0",
+                component_purl="pkg:pypi/a@1.0",
+                cvss_score=5.0,
+                severity="MEDIUM",
+                description="from-clair",
+                scanner="clair",
+                fixed_version="1.2.3",
+                recommendation="upgrade",
+                acceptability_status="acceptable",
+            ),
+        ]
+        # Put lower score first so higher replaces it
+        findings = [findings[1], findings[0]]
+        result = dedup_vulns(findings)
+        assert len(result) == 1
+        assert result[0].cvss_score == 9.0
+        assert result[0].scanner == "trivy"
+        assert result[0].fixed_version == "1.2.3"
+        assert result[0].recommendation == "upgrade"
+        assert result[0].acceptability_status == "acceptable"
+        # Winner already had a description — nonempty fields are not overwritten
+        assert result[0].description == "desc"
+
+
+# ---------------------------------------------------------------------------
+# CVSS cross-component fill
+# ---------------------------------------------------------------------------
+
+def test_zero_score_filled_from_other_component():
+    findings = [
+        _f("CVE-2024-8888", "pkg:pypi/a@1.0", 7.5, "trivy"),
+        _f("CVE-2024-8888", "pkg:pypi/b@2.0", 0.0, "clair"),
+    ]
+    result = dedup_vulns(findings)
+    by_purl = {r.component_purl: r for r in result}
+    assert by_purl["pkg:pypi/b@2.0"].cvss_score == 7.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sbom_pipeline/test_gen_sbom.py
+++ b/tests/unit/sbom_pipeline/test_gen_sbom.py
@@ -248,6 +248,9 @@ class TestSourceRouting:
 
             mock_local_fn.assert_called_once()
             mock_git_fn.assert_not_called()
+            _, kwargs = mock_local_fn.call_args
+            assert "use_cdxgen" in kwargs
+            assert "use_syft" in kwargs
 
     def test_github_source_calls_generate_from_git(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -266,6 +269,26 @@ class TestSourceRouting:
 
             mock_git_fn.assert_called_once()
             mock_local_fn.assert_not_called()
+            _, kwargs = mock_git_fn.call_args
+            assert kwargs.get("use_cdxgen") is True
+            assert kwargs.get("use_syft") is True
+
+    def test_generator_flags_forwarded_to_generate_from_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _cfg(Path(tmp))
+            cfg.use_cdxgen = False
+            cfg.use_syft = True
+
+            mock_local_fn = MagicMock(side_effect=_fake_gen_dir(_MINIMAL_SBOM))
+            with (
+                patch("sbom_pipeline.pipeline.generate.generate_from_dir", mock_local_fn),
+                patch("sbom_pipeline.pipeline._export_reports"),
+            ):
+                gen_sbom(cfg)
+
+            _, kwargs = mock_local_fn.call_args
+            assert kwargs["use_cdxgen"] is False
+            assert kwargs["use_syft"] is True
 
     def test_missing_git_url_raises(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Keep dependency bom-refs valid after component merge, collapse Clair/Trivy duplicates, and preserve remediation fields; also forward --no-cdxgen/--no-syft and write cert --output to the requested path.